### PR TITLE
Multiple fixes and cleanup

### DIFF
--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -52,7 +52,7 @@ impl FcntlRights {
     pub fn from_file<T: AsRawFd>(fd: &T) -> CapResult<FcntlRights> {
         unsafe {
             let mut empty_fcntls = 0;
-            let res = cap_fcntls_get(fd.as_raw_fd() as isize, &mut empty_fcntls as *mut u32);
+            let res = cap_fcntls_get(fd.as_raw_fd(), &mut empty_fcntls as *mut u32);
             if res < 0 {
                 Err(CapErr::from(CapErrType::Get))
             } else {
@@ -65,7 +65,7 @@ impl FcntlRights {
 impl CapRights for FcntlRights {
     fn limit<T: AsRawFd>(&self, fd: &T) -> CapResult<()> {
         unsafe {
-            if cap_fcntls_limit(fd.as_raw_fd() as isize, self.0) < 0 {
+            if cap_fcntls_limit(fd.as_raw_fd(), self.0) < 0 {
                 Err(CapErr::from(CapErrType::Get))
             } else {
                 Ok(())
@@ -81,6 +81,6 @@ impl PartialEq for FcntlRights {
 }
 
 extern "C" {
-    fn cap_fcntls_limit(fd: isize, fcntlrights: u32) -> isize;
-    fn cap_fcntls_get(fd: isize, fcntlrightsp: *mut u32) -> isize;
+    fn cap_fcntls_limit(fd: i32, fcntlrights: u32) -> i32;
+    fn cap_fcntls_get(fd: i32, fcntlrightsp: *mut u32) -> i32;
 }

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -22,7 +22,7 @@ impl FcntlsBuilder {
         FcntlsBuilder(right as u32)
     }
 
-    pub fn add<'a>(&'a mut self, right: Fcntl) -> &'a mut FcntlsBuilder {
+    pub fn add(&mut self, right: Fcntl) -> &mut FcntlsBuilder {
         self.0 |= right as u32;
         self
     }
@@ -35,8 +35,8 @@ impl FcntlsBuilder {
         self.0
     }
 
-    pub fn remove<'a>(&'a mut self, right: Fcntl) -> &'a mut FcntlsBuilder {
-        self.0 = self.0 & (!(right as u32));
+    pub fn remove(&mut self, right: Fcntl) -> &mut FcntlsBuilder {
+        self.0 &= !(right as u32);
         self
     }
 }
@@ -65,7 +65,7 @@ impl FcntlRights {
 impl CapRights for FcntlRights {
     fn limit<T: AsRawFd>(&self, fd: &T) -> CapResult<()> {
         unsafe {
-            if cap_fcntls_limit(fd.as_raw_fd() as isize, self.0 as u32) < 0 {
+            if cap_fcntls_limit(fd.as_raw_fd() as isize, self.0) < 0 {
                 Err(CapErr::from(CapErrType::Get))
             } else {
                 Ok(())

--- a/src/ioctl.rs
+++ b/src/ioctl.rs
@@ -13,7 +13,7 @@ impl IoctlsBuilder {
         IoctlsBuilder(vec![right])
     }
 
-    pub fn add<'a>(&'a mut self, right: u64) -> &'a mut IoctlsBuilder {
+    pub fn add(&mut self, right: u64) -> &mut IoctlsBuilder {
         self.0.push(right);
         self
     }
@@ -22,7 +22,7 @@ impl IoctlsBuilder {
         self.0.clone()
     }
 
-    pub fn remove<'a>(&'a mut self, right: u64) -> &'a mut IoctlsBuilder {
+    pub fn remove(&mut self, right: u64) -> &mut IoctlsBuilder {
         self.0.retain(|&item| item != right);
         self
     }

--- a/src/ioctl.rs
+++ b/src/ioctl.rs
@@ -48,7 +48,7 @@ impl IoctlRights {
     pub fn from_file<T: AsRawFd>(fd: &T, len: usize) -> CapResult<IoctlRights> {
         unsafe {
             let mut cmds = Vec::with_capacity(len);
-            let res = cap_ioctls_get(fd.as_raw_fd() as isize, cmds.as_mut_ptr(), len);
+            let res = cap_ioctls_get(fd.as_raw_fd(), cmds.as_mut_ptr(), len);
             if res == CAP_IOCTLS_ALL {
                 todo!()
             } else if let Ok(rlen) = usize::try_from(res) {
@@ -69,7 +69,7 @@ impl CapRights for IoctlRights {
     fn limit<T: AsRawFd>(&self, fd: &T) -> CapResult<()> {
         unsafe {
             let len = self.0.len();
-            if cap_ioctls_limit(fd.as_raw_fd() as isize, self.0.as_ptr(), len) < 0 {
+            if cap_ioctls_limit(fd.as_raw_fd(), self.0.as_ptr(), len) < 0 {
                 Err(CapErr::from(CapErrType::Limit))
             } else {
                 Ok(())
@@ -85,6 +85,6 @@ impl PartialEq for IoctlRights {
 }
 
 extern "C" {
-    fn cap_ioctls_limit(fd: isize, cmds: *const u64, ncmds: usize) -> isize;
-    fn cap_ioctls_get(fd: isize, cmds: *mut u64, maxcmds: usize) -> isize;
+    fn cap_ioctls_limit(fd: i32, cmds: *const libc::u_long, ncmds: usize) -> i32;
+    fn cap_ioctls_get(fd: i32, cmds: *mut libc::u_long, maxcmds: usize) -> isize;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 /// ## Entering capability mode
 ///
-/// ```ignore
+/// ```no_run
 ///  use capsicum::{enter, sandboxed};
 ///  use std::fs::File;
 ///  use std::io::Read;
@@ -28,31 +28,23 @@
 ///
 /// ## Limit capability rights to files
 ///
-/// ```ignore
+/// ```no_run
 /// use capsicum::{CapRights, Right, RightsBuilder};
 /// use std::fs::File;
 /// use std::io::Read;
 
-/// let x = rand::random::<bool>();
-///
 /// let mut ok_file = File::open("/tmp/foo").unwrap();
 /// let mut s = String::new();
 ///
 /// let mut builder = RightsBuilder::new(Right::Seek);
 ///
-/// if x {
-///     builder.add(Right::Read);
-/// }
-
+/// builder.add(Right::Read);
+///
 /// let rights = builder.finalize().unwrap();
-
+///
 /// rights.limit(&ok_file).unwrap();
 ///
-/// match ok_file.read_to_string(&mut s) {
-///     Ok(_) if x => println!("Allowed reading: x = {} ", x),
-///     Err(_) if !x => println!("Did not allow reading: x = {}", x),
-///     _ => panic!("Not properly sandboxed"),
-/// }
+/// assert!(ok_file.read_to_string(&mut s).is_ok());
 /// ```
 
 extern crate libc;

--- a/src/process.rs
+++ b/src/process.rs
@@ -2,9 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-pub fn enter() -> Result<(), ()> {
+use std::io;
+
+pub fn enter() -> io::Result<()> {
     if unsafe { cap_enter() } < 0 {
-        Err(())
+        Err(io::Error::last_os_error())
     } else {
         Ok(())
     }
@@ -14,11 +16,11 @@ pub fn sandboxed() -> bool {
     unsafe { cap_sandboxed() == 1 }
 }
 
-pub fn get_mode() -> Result<usize, ()> {
+pub fn get_mode() -> io::Result<usize> {
     let mut mode = 0;
     unsafe {
         if cap_getmode(&mut mode as *mut usize) != 0 {
-            return Err(());
+            return Err(io::Error::last_os_error());
         }
     }
     Ok(mode)

--- a/src/process.rs
+++ b/src/process.rs
@@ -11,11 +11,7 @@ pub fn enter() -> Result<(), ()> {
 }
 
 pub fn sandboxed() -> bool {
-    if unsafe { cap_sandboxed() } == 1 {
-        true
-    } else {
-        false
-    }
+    unsafe { cap_sandboxed() == 1 }
 }
 
 pub fn get_mode() -> Result<usize, ()> {

--- a/src/process.rs
+++ b/src/process.rs
@@ -13,21 +13,21 @@ pub fn enter() -> io::Result<()> {
 }
 
 pub fn sandboxed() -> bool {
-    unsafe { cap_sandboxed() == 1 }
+    unsafe { cap_sandboxed() }
 }
 
 pub fn get_mode() -> io::Result<usize> {
     let mut mode = 0;
     unsafe {
-        if cap_getmode(&mut mode as *mut usize) != 0 {
+        if cap_getmode(&mut mode) != 0 {
             return Err(io::Error::last_os_error());
         }
     }
-    Ok(mode)
+    Ok(mode as usize)
 }
 
 extern "C" {
-    fn cap_enter() -> isize;
-    fn cap_sandboxed() -> isize;
-    fn cap_getmode(modep: *mut usize) -> isize;
+    fn cap_enter() -> i32;
+    fn cap_sandboxed() -> bool;
+    fn cap_getmode(modep: *mut u32) -> i32;
 }

--- a/src/right.rs
+++ b/src/right.rs
@@ -129,7 +129,7 @@ impl RightsBuilder {
         RightsBuilder(right as u64)
     }
 
-    pub fn add<'a>(&'a mut self, right: Right) -> &'a mut RightsBuilder {
+    pub fn add(&mut self, right: Right) -> &mut RightsBuilder {
         self.0 |= right as u64;
         self
     }
@@ -142,7 +142,7 @@ impl RightsBuilder {
         self.0
     }
 
-    pub fn remove<'a>(&'a mut self, right: Right) -> &'a mut RightsBuilder {
+    pub fn remove(&mut self, right: Right) -> &mut RightsBuilder {
         self.0 = (self.0 & !(right as u64)) | 0x200000000000000;
         self
     }

--- a/src/right.rs
+++ b/src/right.rs
@@ -12,7 +12,7 @@ use std::os::unix::io::{RawFd, AsRawFd};
 use std::os::raw::c_char;
 use std::ops::BitAnd;
 
-pub const RIGHTS_VERSION: usize = 0;
+pub const RIGHTS_VERSION: i32 = 0;
 
 macro_rules! cap_right {
     ($idx:expr, $bit:expr) => {
@@ -154,7 +154,7 @@ pub struct FileRights(cap_rights_t);
 impl FileRights {
     pub fn new(raw_rights: u64) -> CapResult<FileRights> {
         unsafe {
-            let mut empty_rights = cap_rights_t { cr_rights: [0; RIGHTS_VERSION + 2] };
+            let mut empty_rights = cap_rights_t { cr_rights: [0; RIGHTS_VERSION as usize + 2] };
             let rights_ptr = __cap_rights_init(RIGHTS_VERSION,
                                                &mut empty_rights as *mut cap_rights_t,
                                                raw_rights,
@@ -174,7 +174,7 @@ impl FileRights {
 
     pub fn from_file<T: AsRawFd>(fd: &T) -> CapResult<FileRights> {
         unsafe {
-            let mut empty_rights = cap_rights_t { cr_rights: [0; RIGHTS_VERSION + 2] };
+            let mut empty_rights = cap_rights_t { cr_rights: [0; RIGHTS_VERSION  as usize + 2] };
             let res = __cap_rights_get(RIGHTS_VERSION,
                                        fd.as_raw_fd(),
                                        &mut empty_rights as *mut cap_rights_t);
@@ -273,7 +273,7 @@ impl PartialEq for FileRights {
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct cap_rights_t {
-    cr_rights: [u64; RIGHTS_VERSION + 2],
+    cr_rights: [u64; RIGHTS_VERSION as usize + 2],
 }
 
 extern "C" {
@@ -282,7 +282,7 @@ extern "C" {
     fn cap_rights_remove(dst: *mut cap_rights_t, src: *const cap_rights_t) -> *mut cap_rights_t;
     fn cap_rights_contains(big: *const cap_rights_t, little: *const cap_rights_t) -> bool;
     fn cap_rights_limit(fd: RawFd, rights: *const cap_rights_t) -> RawFd;
-    fn __cap_rights_init(version: usize,
+    fn __cap_rights_init(version: i32,
                          rights: *mut cap_rights_t,
                          raw_rights: u64,
                          sentinel: u64)
@@ -296,7 +296,7 @@ extern "C" {
                           sentinel: u64)
                           -> *mut cap_rights_t;
     fn __cap_rights_is_set(rights: *const cap_rights_t, raw_rights: u64, sentinel: u64) -> bool;
-    fn __cap_rights_get(version: usize, fd: RawFd, rightsp: *mut cap_rights_t) -> RawFd;
+    fn __cap_rights_get(version: i32, fd: RawFd, rightsp: *mut cap_rights_t) -> RawFd;
 }
 
 #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -44,9 +44,9 @@ pub struct Directory {
 
 impl Directory {
     pub fn new(path: &str) -> io::Result<Directory> {
-        let file = try!(File::open(path));
+        let file = File::open(path)?;
         Ok(Directory {
-            file: file,
+            file,
         })
     }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -117,9 +117,12 @@ mod base {
     #[test]
     fn test_ioctl() {
         let file = fs::File::create(TMPFILE3).unwrap();
-        let ioctls = IoctlsBuilder::new(9223372036854775807).add(1).finalize();
+        let ioctls = IoctlsBuilder::new(i64::max_value() as u64)
+            .add(1)
+            .finalize();
         ioctls.limit(&file).unwrap();
-        let _ = IoctlRights::from_file(&file, 10).unwrap();
+        let limited = IoctlRights::from_file(&file, 10).unwrap();
+        assert_eq!(ioctls, limited);
         fs::remove_file(TMPFILE3).unwrap();
     }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -19,10 +19,6 @@ mod base {
     const TMPFILE3: &str = "/tmp/baz";
     const TMPFILE4: &str = "/tmp/qux";
 
-    extern {
-        fn fork() -> isize;
-        fn wait() -> isize;
-    }
 
     #[test]
     fn test_rights_right() {
@@ -91,7 +87,7 @@ mod base {
     #[test]
     fn test_enter() {
         unsafe {
-            let pid = fork();
+            let pid = libc::fork();
             if pid == 0 {
                 fs::File::create(TMPFILE2).unwrap();
                 let mut ok_file = fs::File::open(TMPFILE2).unwrap();
@@ -108,7 +104,7 @@ mod base {
                     panic!("application is not properly sandboxed!");
                 }
             } else {
-                wait();
+                assert_eq!(pid, libc::waitpid(pid, std::ptr::null_mut(), 0));
                 fs::remove_file(TMPFILE2).unwrap();
             }
         }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -126,6 +126,16 @@ mod base {
         fs::remove_file(TMPFILE3).unwrap();
     }
 
+    // https://github.com/dlrobertson/capsicum-rs/issues/5
+    #[test]
+    #[ignore = "IoctlRights cannot respresent unlimited"]
+    fn test_ioctl_unlimited() {
+        let file = fs::File::create(TMPFILE3).unwrap();
+        let _limited = IoctlRights::from_file(&file, 10).unwrap();
+        // TODO: what should limited be?
+        fs::remove_file(TMPFILE3).unwrap();
+    }
+
     #[test]
     fn test_fcntl() {
         let file = fs::File::create(TMPFILE4).unwrap();

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -13,10 +13,11 @@ mod base {
     use std::fs;
     use std::io::{Read, Write};
 
-    const TMPFILE1: &'static str = "/tmp/foo";
-    const TMPFILE2: &'static str = "/tmp/bar";
-    const TMPFILE3: &'static str = "/tmp/baz";
-    const TMPFILE4: &'static str = "/tmp/qux";
+    // TODO: use tempfile instead of hard-coding pathnames.
+    const TMPFILE1: &str = "/tmp/foo";
+    const TMPFILE2: &str = "/tmp/bar";
+    const TMPFILE3: &str = "/tmp/baz";
+    const TMPFILE4: &str = "/tmp/qux";
 
     extern {
         fn fork() -> isize;
@@ -71,7 +72,7 @@ mod base {
                         0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21, 0x00];
 
         // Write should be limitted
-        if let Ok(_) = file.write_all(&c_string) {
+        if file.write_all(&c_string).is_ok() {
             fs::remove_file(TMPFILE1).unwrap();
             panic!("Rights did not correctly limit write");
         }
@@ -98,12 +99,12 @@ mod base {
                 enter().expect("cap_enter failed!");
                 assert!(sandboxed(), "application is not properly sandboxed");
 
-                if let Ok(_) = fs::File::open(TMPFILE1) {
+                if fs::File::open(TMPFILE1).is_ok() {
                     panic!("application is not properly sandboxed!");
                 }
 
                 let mut s = String::new();
-                if let Err(_) = ok_file.read_to_string(&mut s) {
+                if ok_file.read_to_string(&mut s).is_err() {
                     panic!("application is not properly sandboxed!");
                 }
             } else {


### PR DESCRIPTION
- clippy cleanup
- `enter` and `get_mode` now return a `io::Result`
- Fix a stack overflow in IoctlRights::from_file
- Fix FFI bindings
- Add a test for unlimited ioctl rights
- Fix doc tests
- Fix definitions of fork() and wait()