### PR TITLE
Improvements to the integration tests:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ keywords = ["sandbox", "FreeBSD", "capsicum"]
 
 [dependencies]
 libc = "0.2.20"
+
+[dev-dependencies]
+tempfile = "3.0"

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,6 +4,7 @@
 
 
 extern crate capsicum;
+extern crate tempfile;
 
 mod base {
     use capsicum::{enter, sandboxed, CapRights};
@@ -12,12 +13,7 @@ mod base {
     use capsicum::{Fcntl, FcntlRights, FcntlsBuilder};
     use std::fs;
     use std::io::{Read, Write};
-
-    // TODO: use tempfile instead of hard-coding pathnames.
-    const TMPFILE1: &str = "/tmp/foo";
-    const TMPFILE2: &str = "/tmp/bar";
-    const TMPFILE3: &str = "/tmp/baz";
-    const TMPFILE4: &str = "/tmp/qux";
+    use tempfile::{NamedTempFile, tempfile};
 
 
     #[test]
@@ -39,7 +35,7 @@ mod base {
 
     #[test]
     fn test_rights() {
-        let mut file = fs::File::create(TMPFILE1).unwrap();
+        let mut file = NamedTempFile::new().unwrap();
 
         let mut rights = match RightsBuilder::new(Right::Null).finalize() {
             Ok(rights) => rights,
@@ -69,77 +65,69 @@ mod base {
 
         // Write should be limitted
         if file.write_all(&c_string).is_ok() {
-            fs::remove_file(TMPFILE1).unwrap();
             panic!("Rights did not correctly limit write");
         }
 
-        file = fs::File::open(TMPFILE1).unwrap();
-
         let mut s = String::new();
-        file.read_to_string(&mut s).unwrap();
+        let mut rfile = fs::File::open(file.path()).unwrap();
+        rfile.read_to_string(&mut s).unwrap();
 
         // Nothing has been written to the file
         assert_eq!("", s);
-
-        fs::remove_file(TMPFILE1).unwrap();
     }
 
     #[test]
     fn test_enter() {
-        unsafe {
-            let pid = libc::fork();
-            if pid == 0 {
-                fs::File::create(TMPFILE2).unwrap();
-                let mut ok_file = fs::File::open(TMPFILE2).unwrap();
+        let mut file = NamedTempFile::new().unwrap();
+        let pid = unsafe { libc::fork() };
+        if pid == 0 {
+            enter().expect("cap_enter failed!");
+            assert!(sandboxed(), "application is not properly sandboxed");
 
-                enter().expect("cap_enter failed!");
-                assert!(sandboxed(), "application is not properly sandboxed");
-
-                if fs::File::open(TMPFILE1).is_ok() {
-                    panic!("application is not properly sandboxed!");
-                }
-
-                let mut s = String::new();
-                if ok_file.read_to_string(&mut s).is_err() {
-                    panic!("application is not properly sandboxed!");
-                }
-            } else {
-                assert_eq!(pid, libc::waitpid(pid, std::ptr::null_mut(), 0));
-                fs::remove_file(TMPFILE2).unwrap();
+            if fs::File::open(file.path()).is_ok() {
+                panic!("application is not properly sandboxed!");
             }
+
+            let mut s = String::new();
+            if file.read_to_string(&mut s).is_err() {
+                panic!("application is not properly sandboxed!");
+            }
+            unsafe { libc::_exit(0) };
+        } else {
+            let wpid = unsafe { libc::waitpid(pid, std::ptr::null_mut(), 0) };
+            assert_eq!(pid, wpid);
         }
     }
 
     #[test]
     fn test_ioctl() {
-        let file = fs::File::create(TMPFILE3).unwrap();
+        let file = tempfile().unwrap();
         let ioctls = IoctlsBuilder::new(i64::max_value() as u64)
             .add(1)
             .finalize();
         ioctls.limit(&file).unwrap();
         let limited = IoctlRights::from_file(&file, 10).unwrap();
         assert_eq!(ioctls, limited);
-        fs::remove_file(TMPFILE3).unwrap();
     }
 
     // https://github.com/dlrobertson/capsicum-rs/issues/5
     #[test]
     #[ignore = "IoctlRights cannot respresent unlimited"]
     fn test_ioctl_unlimited() {
-        let file = fs::File::create(TMPFILE3).unwrap();
+        let file = tempfile().unwrap();
         let _limited = IoctlRights::from_file(&file, 10).unwrap();
         // TODO: what should limited be?
-        fs::remove_file(TMPFILE3).unwrap();
     }
 
     #[test]
     fn test_fcntl() {
-        let file = fs::File::create(TMPFILE4).unwrap();
-        let fcntls = FcntlsBuilder::new(Fcntl::GetFL).add(Fcntl::GetOwn).finalize();
+        let file = tempfile().unwrap();
+        let fcntls = FcntlsBuilder::new(Fcntl::GetFL)
+            .add(Fcntl::GetOwn)
+            .finalize();
         fcntls.limit(&file).unwrap();
         let new_fcntls = FcntlRights::from_file(&file).unwrap();
         assert_eq!(new_fcntls, fcntls);
-        fs::remove_file(TMPFILE4).unwrap();
     }
 }
 
@@ -154,8 +142,15 @@ mod util {
             .add(Right::Lookup)
             .finalize().unwrap();
         rights.limit(&dir).unwrap();
-        capsicum::enter().unwrap();
-        let path = CString::new("lib.rs").unwrap();
-        let _ = dir.open_file(path, 0, None).unwrap();
+        let pid = unsafe { libc::fork() };
+        if pid == 0 {
+            capsicum::enter().unwrap();
+            let path = CString::new("lib.rs").unwrap();
+            let _ = dir.open_file(path, 0, None).unwrap();
+            unsafe { libc::_exit(0) };
+        } else {
+            let wpid = unsafe { libc::waitpid(pid, std::ptr::null_mut(), 0) };
+            assert_eq!(pid, wpid);
+        }
     }
 }


### PR DESCRIPTION
* Use the tempfile crate instead of hard-coding temporary file names
* Must use _exit(0) at the end of child processes, so we don't run the Rust destructors in both children and parents.
* Minimize use of `unsafe`
* Always run `cap_enter` in a child process.