### PR TITLE
In the tests, correctly check if a child process paniced

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,9 @@ targets = [
 [dependencies]
 libc = "0.2.20"
 
+[build-dependencies]
+version_check = "0.9.4"
+
 [dev-dependencies]
+nix = "0.25.0"
 tempfile = "3.0"

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+extern crate version_check as rustc;
+
 #[cfg(target_os = "freebsd")]
 fn freebsd_nop() {
 }
@@ -9,4 +11,7 @@ fn freebsd_nop() {
 
 fn main() {
     freebsd_nop();
+    if rustc::is_feature_flaggable() == Some(true) {
+        println!("cargo:rustc-cfg=nightly")
+    }
 }


### PR DESCRIPTION
* Must check the child process's exit status
* Must switch the panic handler to SIGABRT, since stack unwinding isn't safe after fork() (requires nightly).