### PR TITLE
Convert crate to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "capsicum"
+edition = "2021"
 version = "0.1.3"
 authors = ["Daniel Robertson <dan.robertson@anidata.org>"]
 license = "MPL-2.0"
 repository = "https://github.com/dlrobertson/capsicum-rs"
+rust-version = "1.62"
 description = """
 Simple intuitive Rust bindings for the FreeBSD capsicum framework
 """

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-extern crate version_check as rustc;
-
 #[cfg(target_os = "freebsd")]
 fn freebsd_nop() {}
 
@@ -10,7 +8,7 @@ fn freebsd_nop() {
 
 fn main() {
     freebsd_nop();
-    if rustc::is_feature_flaggable() == Some(true) {
+    if version_check::is_feature_flaggable() == Some(true) {
         println!("cargo:rustc-cfg=nightly")
     }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+imports_layout = "HorizontalVertical"
+reorder_impl_items = true
+reorder_imports = true

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,9 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::ffi;
-use std::io;
-use std::os::unix::io::AsRawFd;
+use std::{ffi, io, os::unix::io::AsRawFd};
 
 pub enum CapErrType {
     Clear,

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -2,8 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::common::{CapErr, CapErrType, CapResult, CapRights};
 use std::os::unix::io::AsRawFd;
+
+use crate::common::{CapErr, CapErrType, CapResult, CapRights};
 
 #[repr(u32)]
 #[derive(Debug)]

--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use common::{CapErr, CapErrType, CapResult, CapRights};
+use crate::common::{CapErr, CapErrType, CapResult, CapRights};
 use std::os::unix::io::AsRawFd;
 
 #[repr(u32)]

--- a/src/ioctl.rs
+++ b/src/ioctl.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use common::{CapErr, CapErrType, CapResult, CapRights};
+use crate::common::{CapErr, CapErrType, CapResult, CapRights};
 use std::{convert::TryFrom, os::unix::io::AsRawFd};
 
 const CAP_IOCTLS_ALL: isize = isize::max_value();

--- a/src/ioctl.rs
+++ b/src/ioctl.rs
@@ -2,8 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::common::{CapErr, CapErrType, CapResult, CapRights};
 use std::{convert::TryFrom, os::unix::io::AsRawFd};
+
+use crate::common::{CapErr, CapErrType, CapResult, CapRights};
 
 const CAP_IOCTLS_ALL: isize = isize::max_value();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,6 @@
 ///
 /// assert!(ok_file.read_to_string(&mut s).is_ok());
 /// ```
-extern crate libc;
-
 mod common;
 mod fcntl;
 mod ioctl;
@@ -55,7 +53,7 @@ mod process;
 mod right;
 pub mod util;
 
-pub use common::{CapErr, CapResult, CapRights};
+pub use crate::common::{CapErr, CapResult, CapRights};
 pub use fcntl::{Fcntl, FcntlRights, FcntlsBuilder};
 pub use ioctl::{IoctlRights, IoctlsBuilder};
 pub use process::{enter, get_mode, sandboxed};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,9 @@ mod process;
 mod right;
 pub mod util;
 
-pub use crate::common::{CapErr, CapResult, CapRights};
 pub use fcntl::{Fcntl, FcntlRights, FcntlsBuilder};
 pub use ioctl::{IoctlRights, IoctlsBuilder};
 pub use process::{enter, get_mode, sandboxed};
 pub use right::{FileRights, Right, RightsBuilder};
+
+pub use crate::common::{CapErr, CapResult, CapRights};

--- a/src/right.rs
+++ b/src/right.rs
@@ -6,7 +6,7 @@
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 
-use common::{CapErr, CapErrType, CapResult, CapRights};
+use crate::common::{CapErr, CapErrType, CapResult, CapRights};
 use libc::cap_rights_t;
 use std::io;
 use std::mem;

--- a/src/right.rs
+++ b/src/right.rs
@@ -6,13 +6,19 @@
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 
-use crate::common::{CapErr, CapErrType, CapResult, CapRights};
+use std::{
+    io,
+    mem,
+    ops::BitAnd,
+    os::{
+        raw::c_char,
+        unix::io::{AsRawFd, RawFd},
+    },
+};
+
 use libc::cap_rights_t;
-use std::io;
-use std::mem;
-use std::ops::BitAnd;
-use std::os::raw::c_char;
-use std::os::unix::io::{AsRawFd, RawFd};
+
+use crate::common::{CapErr, CapErrType, CapResult, CapRights};
 
 pub const RIGHTS_VERSION: i32 = 0;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,15 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use libc::{c_int, c_uint, mode_t, openat};
-use std::ffi::CString;
-use std::fs::File;
-use std::io;
-use std::os::unix::{
-    ffi::OsStrExt,
-    io::{AsRawFd, FromRawFd, RawFd},
+use std::{
+    ffi::CString,
+    fs::File,
+    io,
+    os::unix::{
+        ffi::OsStrExt,
+        io::{AsRawFd, FromRawFd, RawFd},
+    },
+    path::Path,
 };
-use std::path::Path;
+
+use libc::{c_int, c_uint, mode_t, openat};
 
 use crate::common::{CapErr, CapErrType, CapResult};
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,7 +12,7 @@ use std::os::unix::{
 };
 use std::path::Path;
 
-use common::{CapErr, CapErrType, CapResult};
+use crate::common::{CapErr, CapErrType, CapResult};
 
 /// Directory with a set of capabilities.
 ///

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -16,16 +16,31 @@ fn always_abort() {
 }
 
 mod base {
-    use super::*;
-    use capsicum::{enter, sandboxed, CapRights};
-    use capsicum::{Fcntl, FcntlRights, FcntlsBuilder};
-    use capsicum::{FileRights, Right, RightsBuilder};
-    use capsicum::{IoctlRights, IoctlsBuilder};
-    use nix::sys::wait::{waitpid, WaitStatus};
-    use nix::unistd::{fork, ForkResult};
-    use std::fs;
-    use std::io::{Read, Write};
+    use std::{
+        fs,
+        io::{Read, Write},
+    };
+
+    use capsicum::{
+        enter,
+        sandboxed,
+        CapRights,
+        Fcntl,
+        FcntlRights,
+        FcntlsBuilder,
+        FileRights,
+        IoctlRights,
+        IoctlsBuilder,
+        Right,
+        RightsBuilder,
+    };
+    use nix::{
+        sys::wait::{waitpid, WaitStatus},
+        unistd::{fork, ForkResult},
+    };
     use tempfile::{tempfile, NamedTempFile};
+
+    use super::*;
 
     #[test]
     fn test_rights_right() {
@@ -149,13 +164,16 @@ mod base {
 }
 
 mod util {
-    use super::*;
-    use capsicum::util::Directory;
-    use capsicum::{self, CapRights, Right, RightsBuilder};
-    use nix::sys::wait::{waitpid, WaitStatus};
-    use nix::unistd::{fork, ForkResult};
     use std::fs;
+
+    use capsicum::{self, util::Directory, CapRights, Right, RightsBuilder};
+    use nix::{
+        sys::wait::{waitpid, WaitStatus},
+        unistd::{fork, ForkResult},
+    };
     use tempfile::tempdir;
+
+    use super::*;
 
     #[test]
     fn test_basic_dir() {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,10 +4,6 @@
 
 #![cfg_attr(nightly, feature(panic_always_abort))]
 
-extern crate capsicum;
-extern crate nix;
-extern crate tempfile;
-
 /// Switch the panic handler to SIGABRT, since stack unwinding can't be safely
 /// done after a fork.
 #[cfg(nightly)]


### PR DESCRIPTION
And use grouped use statements, enabled by edition 2018.