### PR TITLE
Prefer to define FFI functions in libc

### DIFF
--- a/src/fcntl.rs
+++ b/src/fcntl.rs
@@ -41,7 +41,7 @@ impl FcntlsBuilder {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Eq, PartialEq)]
 pub struct FcntlRights(u32);
 
 impl FcntlRights {
@@ -71,12 +71,6 @@ impl CapRights for FcntlRights {
                 Ok(())
             }
         }
-    }
-}
-
-impl PartialEq for FcntlRights {
-    fn eq(&self, other: &FcntlRights) -> bool {
-        self.0 == other.0
     }
 }
 

--- a/src/ioctl.rs
+++ b/src/ioctl.rs
@@ -34,7 +34,7 @@ impl IoctlsBuilder {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Eq, PartialEq)]
 pub struct IoctlRights(Vec<u64>);
 
 impl IoctlRights {
@@ -72,12 +72,6 @@ impl CapRights for IoctlRights {
                 Ok(())
             }
         }
-    }
-}
-
-impl PartialEq for IoctlRights {
-    fn eq(&self, other: &IoctlRights) -> bool {
-        self.0 == other.0
     }
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -5,7 +5,7 @@
 use std::io;
 
 pub fn enter() -> io::Result<()> {
-    if unsafe { cap_enter() } < 0 {
+    if unsafe { libc::cap_enter() } < 0 {
         Err(io::Error::last_os_error())
     } else {
         Ok(())
@@ -19,7 +19,7 @@ pub fn sandboxed() -> bool {
 pub fn get_mode() -> io::Result<usize> {
     let mut mode = 0;
     unsafe {
-        if cap_getmode(&mut mode) != 0 {
+        if libc::cap_getmode(&mut mode) != 0 {
             return Err(io::Error::last_os_error());
         }
     }
@@ -27,7 +27,5 @@ pub fn get_mode() -> io::Result<usize> {
 }
 
 extern "C" {
-    fn cap_enter() -> i32;
     fn cap_sandboxed() -> bool;
-    fn cap_getmode(modep: *mut u32) -> i32;
 }


### PR DESCRIPTION
Where possible, use libc's FFI definitions instead of our own.

Partially addresses #18