### PR TITLE
Replace CapErr with io::Error

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -2,49 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::{ffi, io, os::unix::io::AsRawFd};
-
-pub enum CapErrType {
-    Clear,
-    Generic,
-    Get,
-    Invalid,
-    Limit,
-    Merge,
-    Remove,
-    Set,
-}
-
-#[derive(Debug)]
-pub enum CapErr {
-    Clear(io::Error),
-    Generic(io::Error),
-    Get(io::Error),
-    Invalid(io::Error),
-    Limit(io::Error),
-    Merge(io::Error),
-    Nul(ffi::NulError),
-    Remove(io::Error),
-    Set(io::Error),
-}
-
-impl From<CapErrType> for CapErr {
-    fn from(other: CapErrType) -> CapErr {
-        match other {
-            CapErrType::Clear => CapErr::Clear(io::Error::last_os_error()),
-            CapErrType::Generic => CapErr::Generic(io::Error::last_os_error()),
-            CapErrType::Get => CapErr::Get(io::Error::last_os_error()),
-            CapErrType::Invalid => CapErr::Invalid(io::Error::last_os_error()),
-            CapErrType::Limit => CapErr::Limit(io::Error::last_os_error()),
-            CapErrType::Merge => CapErr::Merge(io::Error::last_os_error()),
-            CapErrType::Remove => CapErr::Remove(io::Error::last_os_error()),
-            CapErrType::Set => CapErr::Set(io::Error::last_os_error()),
-        }
-    }
-}
-
-pub type CapResult<T> = Result<T, CapErr>;
+use std::{io, os::unix::io::AsRawFd};
 
 pub trait CapRights: Sized {
-    fn limit<T: AsRawFd>(&self, fd: &T) -> CapResult<()>;
+    fn limit<T: AsRawFd>(&self, fd: &T) -> io::Result<()>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 ///
 /// builder.add(Right::Read);
 ///
-/// let rights = builder.finalize().unwrap();
+/// let rights = builder.finalize();
 ///
 /// rights.limit(&ok_file).unwrap();
 ///
@@ -58,4 +58,4 @@ pub use ioctl::{IoctlRights, IoctlsBuilder};
 pub use process::{enter, get_mode, sandboxed};
 pub use right::{FileRights, Right, RightsBuilder};
 
-pub use crate::common::{CapErr, CapResult, CapRights};
+pub use crate::common::CapRights;


### PR DESCRIPTION
CapErr simply served to wrap an io::Error around an enum that mainly just served to tell the user what function he had just called.  But the user already knew that.  Simpler just to return io::Error directly.  The only complication was Directory::open_file, which needs to handle a NulError.  I mapped that to io::Error with an ErrorKind of Other.

Fixes #25