### PR TITLE
Fix capsicum manifest for cargo publish

### DIFF
--- a/capsicum/Cargo.toml
+++ b/capsicum/Cargo.toml
@@ -28,10 +28,11 @@ casper = [ "casper-sys", "libnv", "libnv-sys" ]
 [[example]]
 name = "getuid"
 required-features = ["casper"]
+path = "examples/getuid.rs"
 
 [dependencies]
 libc = { version = "0.2.138", features = [ "extra_traits" ] }
-casper-sys = { path = "../casper-sys", optional = true}
+casper-sys = { path = "../casper-sys", optional = true, version = "0.1.0" }
 libnv = { version = "0.4.1", default_features = false, features = [ "libnv" ], optional = true }
 libnv-sys = { version = "0.2.0", optional = true }
 const-cstr = "0.3.0"


### PR DESCRIPTION
 - Add a version for the casper-sys dependency. This is needed to publish to crates.io.
    See [Specifying Path Dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-path-dependencies) for details.
 - Add an `example.path` for the `guid` example.