### PR TITLE
Fix cross-compiling the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased] - ReleaseDate
+
+### Fixed
+
+- Fixed cross-building the documentation.
+  ([#42](https://github.com/dlrobertson/capsicum-rs/pull/42))

--- a/capsicum/Cargo.toml
+++ b/capsicum/Cargo.toml
@@ -33,8 +33,8 @@ path = "examples/getuid.rs"
 [dependencies]
 libc = { version = "0.2.138", features = [ "extra_traits" ] }
 casper-sys = { path = "../casper-sys", optional = true, version = "0.1.0" }
-libnv = { version = "0.4.1", default_features = false, features = [ "libnv" ], optional = true }
-libnv-sys = { version = "0.2.0", optional = true }
+libnv = { version = "0.4.2", default_features = false, features = [ "libnv" ], optional = true }
+libnv-sys = { version = "0.2.1", optional = true }
 const-cstr = "0.3.0"
 ctor = "0.1.26"
 
@@ -43,5 +43,5 @@ version_check = "0.9.4"
 
 [dev-dependencies]
 nix = { version = "0.26.1", default_features = false, features = [ "ioctl", "process" ] }
-libnv-sys = "0.2.0"
+libnv-sys = "0.2.1"
 tempfile = "3.0"

--- a/capsicum/build.rs
+++ b/capsicum/build.rs
@@ -1,13 +1,9 @@
-#[cfg(target_os = "freebsd")]
-fn freebsd_nop() {}
-
-#[cfg(not(target_os = "freebsd"))]
-fn freebsd_nop() {
-    panic!("This is a FreeBSD only crate. It will not compile on other OSes.");
-}
+use std::env;
 
 fn main() {
-    freebsd_nop();
+    if env::var("CARGO_CFG_TARGET_OS").unwrap() != "freebsd" {
+        panic!("This is a FreeBSD only crate. It will not compile for other operating systems.");
+    }
     if version_check::is_feature_flaggable() == Some(true) {
         println!("cargo:rustc-cfg=nightly")
     }

--- a/casper-sys/Cargo.toml
+++ b/casper-sys/Cargo.toml
@@ -15,4 +15,4 @@ keywords = ["sandbox", "FreeBSD", "capsicum"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libnv-sys = "0.2.0"
+libnv-sys = "0.2.1"


### PR DESCRIPTION
There were two problems:

* capsicum's build script deliberately aborted when building _on_ non-FreeBSD, instead of building _for_ non-FreeBSD.

* docs.rs always builds docs on Linux.  So crates that require bindgen at build time, like libnv-sys, generally fail to compile there. libnv-sys tries to detect if it's being built on docs.rs and stubs out the FFI functions instead.  However, it wasn't stubbing out enough functions for capsicum to build.  That's fixed in https://github.com/Inner-Heaven/libnv-rs/pull/28 .

Fixes #41