### PR TITLE
Update CI images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,21 +19,21 @@ task:
         image: freebsd-12-4-release-amd64
     - name: FreeBSD 13 amd64 nightly
       freebsd_instance:
-        image: freebsd-13-1-release-amd64
+        image: freebsd-13-2-release-amd64
     - name: FreeBSD 14 amd64 nightly
       freebsd_instance:
-        image: freebsd-14-0-current-amd64-v20221110
+        image_family: freebsd-14-0-snap
     - name: FreeBSD 13 amd64 stable
       env:
         VERSION: 1.62.0
       freebsd_instance:
-        image: freebsd-13-1-release-amd64
+        image: freebsd-13-2-release-amd64
     - name: FreeBSD 13 i686 nightly
       # Test i686 FreeBSD in 32-bit emulation on a 64-bit host.
       env:
         TARGET: i686-unknown-freebsd
       freebsd_instance:
-        image: freebsd-13-1-release-amd64
+        image: freebsd-13-2-release-amd64
   << : *SETUP
   extra_setup_script:
     - . $HOME/.cargo/env
@@ -60,7 +60,7 @@ lint_task:
     HOME: /tmp  # cargo cache needs it
     VERSION: nightly
   freebsd_instance:
-    image: freebsd-13-1-release-amd64
+    image: freebsd-13-2-release-amd64
   << : *SETUP
   extra_setup_script:
     - . $HOME/.cargo/env


### PR DESCRIPTION
* Update FreeBSD 13 to 13.2.  13.1 will soon be EoL
* Use the lastest 14 snapshot instead of an old pinned version.