### PR TITLE
Use &'static CStr for capsicum::casper::Service::SERVICE_NAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- The `capsicum::casper::Service` trait's `SERVICE_NAME` field must now be
+  defined as a `&'static CStr`.  The [cstr](https://crates.io/crates/cstr)
+  crate can help.
+  ([#49](https://github.com/dlrobertson/capsicum-rs/pull/49))
+
 ### Fixed
 
 - Fixed cross-building the documentation.

--- a/capsicum/Cargo.toml
+++ b/capsicum/Cargo.toml
@@ -35,13 +35,13 @@ libc = { version = "0.2.138", features = [ "extra_traits" ] }
 casper-sys = { path = "../casper-sys", optional = true, version = "0.1.0" }
 libnv = { version = "0.4.2", default_features = false, features = [ "libnv" ], optional = true }
 libnv-sys = { version = "0.2.1", optional = true }
-const-cstr = "0.3.0"
 ctor = "0.1.26"
 
 [build-dependencies]
 version_check = "0.9.4"
 
 [dev-dependencies]
+cstr = "0.2.11"
 nix = { version = "0.26.1", default_features = false, features = [ "fs", "ioctl", "process", "socket" ] }
 libnv-sys = "0.2.1"
 tempfile = "3.0"

--- a/capsicum/examples/getuid.rs
+++ b/capsicum/examples/getuid.rs
@@ -1,15 +1,15 @@
 //! A toy Casper service that provides `getuid()`.
 
-use std::io;
+use std::{ffi::CStr, io};
 
 use capsicum::casper::{self, Casper, NvError, NvFlag, NvList, ServiceRegisterFlags};
-use const_cstr::{const_cstr, ConstCStr};
+use cstr::cstr;
 use libc::uid_t;
 
 /// The Capser `uid` helper process.
 struct CapUid {}
 impl casper::Service for CapUid {
-    const SERVICE_NAME: ConstCStr = const_cstr!("getuid");
+    const SERVICE_NAME: &'static CStr = cstr!("getuid");
 
     fn cmd(
         cmd: &str,


### PR DESCRIPTION
This is more flexible than using const_cstr::ConstCStr.  It also fixes a RUSTSEC issue.  But it is unfortunately backwards-incompatible.

https://rustsec.org/advisories/RUSTSEC-2023-0020