### PR TITLE
Pass CStr to libnv instead of str

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,7 @@ task:
     #image_family: freebsd-14-0-snap
     - name: FreeBSD 13 amd64 stable
       env:
-        VERSION: 1.62.0
+        VERSION: 1.69.0
       freebsd_instance:
         image: freebsd-13-2-release-amd64
     - name: FreeBSD 13 i686 nightly

--- a/capsicum/Cargo.toml
+++ b/capsicum/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.2.0"
 authors = ["Dan Robertson <dan@dlrobertson.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/dlrobertson/capsicum-rs"
-rust-version = "1.62"
+rust-version = "1.69"
 description = """
 Simple intuitive Rust bindings for the FreeBSD capsicum framework
 """

--- a/capsicum/examples/getuid.rs
+++ b/capsicum/examples/getuid.rs
@@ -26,7 +26,7 @@ impl casper::Service for CapUid {
 
         // This C function is always safe
         let uid = unsafe { libc::getuid() };
-        nvout.insert_number("uid", uid).unwrap();
+        nvout.insert_number(cstr!("uid"), uid).unwrap();
         Ok(())
     }
 
@@ -47,9 +47,9 @@ impl CapAgent {
     // `getuid` works fine in capability mode, but it's a nice simple demo.
     pub fn uid(&mut self) -> io::Result<uid_t> {
         let mut invl = NvList::new(NvFlag::None).unwrap();
-        invl.insert_string("cmd", "getuid").unwrap();
+        invl.insert_string(cstr!("cmd"), cstr!("getuid")).unwrap();
         let onvl = self.xfer_nvlist(invl)?;
-        match onvl.get_number("uid") {
+        match onvl.get_number(cstr!("uid")) {
             Ok(Some(uid)) => Ok(uid as uid_t),
             Ok(None) => panic!("zygote did not return the expected value"),
             Err(NvError::NativeError(e)) => Err(io::Error::from_raw_os_error(e)),

--- a/capsicum/src/casper/mod.rs
+++ b/capsicum/src/casper/mod.rs
@@ -211,7 +211,8 @@ mod macros {
                         // Safe because libcasper guarantees its validity, and
                         // we never access it directly after this.
                         let nvl = unsafe{ $crate::casper::NvList::from_ptr(r) };
-                        match nvl.get_number("error") {
+                        let key = ::std::ffi::CStr::from_bytes_until_nul(b"error\0").unwrap();
+                        match nvl.get_number(key) {
                             Ok(Some(0)) => Ok(nvl),
                             Ok(Some(e)) => Err(::std::io::Error::from_raw_os_error(e as i32)),
                             Ok(None) => panic!("zygote did not return error code"),


### PR DESCRIPTION
If supplied with str, libnv will convert it to cstr.  Using cstr directly is more efficient.

Fixes #36