### PR TITLE
capsicum::get_mode should return a bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   crate can help.
   ([#49](https://github.com/dlrobertson/capsicum-rs/pull/49))
 
+- `capsicum::get_mode` now returns a `bool`.
+  ([#51](https://github.com/dlrobertson/capsicum-rs/pull/51))
+
 ### Fixed
 
 - Fixed cross-building the documentation.

--- a/capsicum/src/process.rs
+++ b/capsicum/src/process.rs
@@ -25,12 +25,12 @@ pub fn sandboxed() -> bool {
 /// # Errors
 ///
 /// * `ENOSYS` - The kernel was compiled without capability support.
-pub fn get_mode() -> io::Result<usize> {
+pub fn get_mode() -> io::Result<bool> {
     let mut mode = 0;
     unsafe {
         if libc::cap_getmode(&mut mode) != 0 {
             return Err(io::Error::last_os_error());
         }
     }
-    Ok(mode as usize)
+    Ok(mode != 0)
 }


### PR DESCRIPTION
Because cap_getmode is defined as returning either "zero" or "non-zero"

Fixes #45