### PR TITLE
Switch to resolver=2 for the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
+resolver = "2"
 members = ["capsicum", "casper-sys"]


### PR DESCRIPTION
It's the default for edition 2021, but not the default for workspaces.