### PR TITLE
Enable all features when building docs for docs.rs

### DIFF
--- a/capsicum/Cargo.toml
+++ b/capsicum/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["os::freebsd-apis"]
 include = ["src/**/*", "test/**/*", "build.rs", "LICENSE", "README.md", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 targets = [
   "x86_64-unknown-freebsd",


### PR DESCRIPTION
The currently availble docs don't include the casper feature.