### PR TITLE
In the Casper macros, fully document all public symbols

### DIFF
--- a/capsicum/examples/getuid.rs
+++ b/capsicum/examples/getuid.rs
@@ -1,4 +1,5 @@
 //! A toy Casper service that provides `getuid()`.
+#![warn(missing_docs)]
 
 use std::{ffi::CStr, io};
 

--- a/capsicum/src/casper/mod.rs
+++ b/capsicum/src/casper/mod.rs
@@ -224,7 +224,11 @@ mod macros {
                 }
             }
 
+            /// Extension trait for [`::capsicum::casper::Casper`] that spawns this service.
             $vis trait CasperExt {
+                /// Spawn the
+                #[doc = stringify!($meth)]
+                /// service.
                 fn $meth(&self) -> ::std::io::Result<$astruct>;
             }
             impl CasperExt for ::capsicum::casper::Casper {


### PR DESCRIPTION
This allows the macros to work in consumer crates that "#[deny(missing_docs)]"