### PR TITLE
Overhaul the IoctlsBuilder and FcntlsBuilder APIs

### DIFF
--- a/capsicum/CHANGELOG.md
+++ b/capsicum/CHANGELOG.md
@@ -19,6 +19,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * `IoctlsBuilder`'s methods now pass by move.
   * The `IoctlsBuilder::raw`, `FcntlsBuilder::raw`, `IoctlRights::new`, and
     `FcntlRights::new` methods are all deprecated.
+  * Their `add` and `remove` methods have been renamed to `allow`/`deny`,
+    respectively.
+  ([#71](https://github.com/dlrobertson/capsicum-rs/pull/71))
+
+- The `RightsBuilder`'s `add`/`remove` methods have been renamed to
+  `allow`/`deny`, respectively.  Also, `FileRights`'s `set`/`clear` methods
+  have been renamed to `allow`/`deny`.
   ([#71](https://github.com/dlrobertson/capsicum-rs/pull/71))
 
 ### Removed

--- a/capsicum/CHANGELOG.md
+++ b/capsicum/CHANGELOG.md
@@ -10,6 +10,17 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Implemented `Send` and `Sync` for `CapChannel`.
   ([#66](https://github.com/dlrobertson/capsicum-rs/pull/66))
 
+### Changed
+
+- The `IoctlsBuilder` and `FcntlsBuilder` APIs have the following changes:
+  * They are both now `Clone`.
+  * Their `new` methods no longer take arguments.  The value formerly supplied
+    as an argument must now be supplied by the `add` methods.
+  * `IoctlsBuilder`'s methods now pass by move.
+  * The `IoctlsBuilder::raw`, `FcntlsBuilder::raw`, `IoctlRights::new`, and
+    `FcntlRights::new` methods are all deprecated.
+  ([#71](https://github.com/dlrobertson/capsicum-rs/pull/71))
+
 ### Removed
 
 - `util::Directory` is deprecated.  Use the `cap-std` crate instead.

--- a/capsicum/src/fcntl.rs
+++ b/capsicum/src/fcntl.rs
@@ -32,8 +32,8 @@ pub enum Fcntl {
 /// ```
 /// # use capsicum::{Fcntl, FcntlsBuilder};
 /// let rights = FcntlsBuilder::new()
-///     .add(Fcntl::GetFL)
-///     .add(Fcntl::SetFL)
+///     .allow(Fcntl::GetFL)
+///     .allow(Fcntl::SetFL)
 ///     .finalize();
 /// ```
 #[derive(Clone, Debug, Default)]
@@ -44,6 +44,11 @@ impl FcntlsBuilder {
         FcntlsBuilder::default()
     }
 
+    #[deprecated(since = "0.4.0", note = "use FcntlsBuilder::allow instead")]
+    pub fn add(&mut self, right: Fcntl) -> &mut FcntlsBuilder {
+        self.allow(right)
+    }
+
     /// Allow an additional fcntl
     ///
     /// # Examples
@@ -51,9 +56,9 @@ impl FcntlsBuilder {
     /// # use capsicum::{Fcntl, FcntlsBuilder};
     ///
     /// let mut builder = FcntlsBuilder::new();
-    /// builder.add(Fcntl::GetFL);
+    /// builder.allow(Fcntl::GetFL);
     /// ```
-    pub fn add(&mut self, right: Fcntl) -> &mut FcntlsBuilder {
+    pub fn allow(&mut self, right: Fcntl) -> &mut FcntlsBuilder {
         self.0 |= right as u32;
         self
     }
@@ -62,9 +67,17 @@ impl FcntlsBuilder {
         FcntlRights(self.0)
     }
 
-    #[deprecated(since = "0.4.0", note = "If you still need this method, please file an issue at https://github.com/dlrobertson/capsicum-rs/issues")]
+    #[deprecated(
+        since = "0.4.0",
+        note = "If you still need this method, please file an issue at https://github.com/dlrobertson/capsicum-rs/issues"
+    )]
     pub fn raw(&self) -> u32 {
         self.0
+    }
+
+    #[deprecated(since = "0.4.0", note = "use FcntlsBuilder::deny instead")]
+    pub fn remove(&mut self, right: Fcntl) -> &mut FcntlsBuilder {
+        self.deny(right)
     }
 
     /// Remove an allowed fcntl from the builder's list.
@@ -73,12 +86,12 @@ impl FcntlsBuilder {
     /// ```
     /// # use capsicum::{Fcntl, FcntlsBuilder};
     /// let mut common_builder = FcntlsBuilder::new();
-    /// common_builder.add(Fcntl::GetFL);
-    /// common_builder.add(Fcntl::SetFL);
+    /// common_builder.allow(Fcntl::GetFL);
+    /// common_builder.allow(Fcntl::SetFL);
     /// let mut restricted_builder = common_builder.clone();
-    /// restricted_builder.remove(Fcntl::SetFL);
+    /// restricted_builder.deny(Fcntl::SetFL);
     /// ```
-    pub fn remove(&mut self, right: Fcntl) -> &mut FcntlsBuilder {
+    pub fn deny(&mut self, right: Fcntl) -> &mut FcntlsBuilder {
         self.0 &= !(right as u32);
         self
     }
@@ -100,7 +113,7 @@ impl FcntlsBuilder {
 /// use nix::fcntl::{FcntlArg, OFlag, fcntl};
 /// let file = tempfile().unwrap();
 /// let rights = FcntlsBuilder::new()
-///     .add(Fcntl::GetFL)
+///     .allow(Fcntl::GetFL)
 ///     .finalize();
 ///
 /// rights.limit(&file).unwrap();

--- a/capsicum/src/fcntl.rs
+++ b/capsicum/src/fcntl.rs
@@ -31,16 +31,17 @@ pub enum Fcntl {
 /// # Example
 /// ```
 /// # use capsicum::{Fcntl, FcntlsBuilder};
-/// let rights = FcntlsBuilder::new(Fcntl::GetFL)
+/// let rights = FcntlsBuilder::new()
+///     .add(Fcntl::GetFL)
 ///     .add(Fcntl::SetFL)
 ///     .finalize();
 /// ```
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct FcntlsBuilder(u32);
 
 impl FcntlsBuilder {
-    pub fn new(right: Fcntl) -> FcntlsBuilder {
-        FcntlsBuilder(right as u32)
+    pub fn new() -> FcntlsBuilder {
+        FcntlsBuilder::default()
     }
 
     pub fn add(&mut self, right: Fcntl) -> &mut FcntlsBuilder {
@@ -77,7 +78,8 @@ impl FcntlsBuilder {
 /// use nix::errno::Errno;
 /// use nix::fcntl::{FcntlArg, OFlag, fcntl};
 /// let file = tempfile().unwrap();
-/// let rights = FcntlsBuilder::new(Fcntl::GetFL)
+/// let rights = FcntlsBuilder::new()
+///     .add(Fcntl::GetFL)
 ///     .finalize();
 ///
 /// rights.limit(&file).unwrap();

--- a/capsicum/src/fcntl.rs
+++ b/capsicum/src/fcntl.rs
@@ -44,19 +44,40 @@ impl FcntlsBuilder {
         FcntlsBuilder::default()
     }
 
+    /// Allow an additional fcntl
+    ///
+    /// # Examples
+    /// ```
+    /// # use capsicum::{Fcntl, FcntlsBuilder};
+    ///
+    /// let mut builder = FcntlsBuilder::new();
+    /// builder.add(Fcntl::GetFL);
+    /// ```
     pub fn add(&mut self, right: Fcntl) -> &mut FcntlsBuilder {
         self.0 |= right as u32;
         self
     }
 
     pub fn finalize(&self) -> FcntlRights {
-        FcntlRights::new(self.0)
+        FcntlRights(self.0)
     }
 
+    #[deprecated(since = "0.4.0", note = "If you still need this method, please file an issue at https://github.com/dlrobertson/capsicum-rs/issues")]
     pub fn raw(&self) -> u32 {
         self.0
     }
 
+    /// Remove an allowed fcntl from the builder's list.
+    ///
+    /// # Example
+    /// ```
+    /// # use capsicum::{Fcntl, FcntlsBuilder};
+    /// let mut common_builder = FcntlsBuilder::new();
+    /// common_builder.add(Fcntl::GetFL);
+    /// common_builder.add(Fcntl::SetFL);
+    /// let mut restricted_builder = common_builder.clone();
+    /// restricted_builder.remove(Fcntl::SetFL);
+    /// ```
     pub fn remove(&mut self, right: Fcntl) -> &mut FcntlsBuilder {
         self.0 &= !(right as u32);
         self
@@ -95,6 +116,8 @@ impl FcntlsBuilder {
 pub struct FcntlRights(u32);
 
 impl FcntlRights {
+    #[allow(missing_docs)]
+    #[deprecated(since = "0.4.0", note = "use FcntlsBuilder insted")]
     pub fn new(right: u32) -> FcntlRights {
         FcntlRights(right)
     }

--- a/capsicum/src/ioctl.rs
+++ b/capsicum/src/ioctl.rs
@@ -16,9 +16,9 @@ const CAP_IOCTLS_ALL: isize = isize::max_value();
 /// Using ioctl command codes from libc:
 /// ```
 /// # use capsicum::IoctlsBuilder;
-/// let mut builder = IoctlsBuilder::new();
-/// builder.add(libc::TIOCGETD);
-/// let rights = builder.finalize();
+/// let rights = IoctlsBuilder::new()
+///     .add(libc::TIOCGETD)
+///     .finalize();
 /// ```
 /// Declaring ioctl command codes with Nix, for ioctls not present in libc:
 /// ```
@@ -29,9 +29,9 @@ const CAP_IOCTLS_ALL: isize = isize::max_value();
 /// const TIOCGETD: libc::u_long = request_code_read!(b't', 26, mem::size_of::<libc::c_int>());
 ///
 /// fn main() {
-///     let mut builder = IoctlsBuilder::new();
-///     builder.add(TIOCGETD);
-///     let rights = builder.finalize();
+///     let rights = IoctlsBuilder::new()
+///         .add(TIOCGETD)
+///         .finalize();
 /// }
 #[derive(Clone, Debug, Default)]
 pub struct IoctlsBuilder(Vec<u_long>);
@@ -51,7 +51,7 @@ impl IoctlsBuilder {
     /// let mut builder = IoctlsBuilder::new();
     /// builder.add(libc::TIOCGETD);
     /// ```
-    pub fn add(&mut self, right: u_long) -> &mut IoctlsBuilder {
+    pub fn add(mut self, right: u_long) -> Self {
         self.0.push(right);
         self
     }
@@ -67,20 +67,20 @@ impl IoctlsBuilder {
     /// # Example
     /// ```
     /// # use capsicum::IoctlsBuilder;
-    /// let mut common_builder = IoctlsBuilder::new();
-    /// common_builder.add(libc::TIOCGETD);
-    /// common_builder.add(libc::TIOCSETD);
-    /// let mut restricted_builder = common_builder.clone();
-    /// restricted_builder.remove(libc::TIOCSETD);
+    /// let common_builder = IoctlsBuilder::new();
+    /// let common_builder = common_builder.add(libc::TIOCGETD);
+    /// let common_builder = common_builder.add(libc::TIOCSETD);
+    /// let restricted_builder = common_builder.clone();
+    /// let restricted_builder = restricted_builder.remove(libc::TIOCSETD);
     /// ```
-    pub fn remove(&mut self, right: u_long) -> &mut IoctlsBuilder {
+    pub fn remove(mut self, right: u_long) -> Self {
         self.0.retain(|&item| item != right);
         self
     }
 
     /// Finish this `IoctlsBuilder` into an [`IoctlRights`] object.
-    pub fn finalize(&self) -> IoctlRights {
-        IoctlRights::Limited(self.0.clone())
+    pub fn finalize(self) -> IoctlRights {
+        IoctlRights::Limited(self.0)
     }
 }
 

--- a/capsicum/src/lib.rs
+++ b/capsicum/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //! let mut builder = RightsBuilder::new(Right::Seek);
 //!
-//! builder.add(Right::Read);
+//! builder.allow(Right::Read);
 //!
 //! let rights = builder.finalize();
 //!

--- a/capsicum/src/right.rs
+++ b/capsicum/src/right.rs
@@ -156,7 +156,7 @@ pub enum Right {
 /// ```
 /// # use capsicum::{Right, RightsBuilder};
 /// let rights = RightsBuilder::new(Right::Read)
-///     .add(Right::Fexecve)
+///     .allow(Right::Fexecve)
 ///     .finalize();
 /// ```
 #[derive(Debug, Default)]
@@ -167,7 +167,12 @@ impl RightsBuilder {
         RightsBuilder(right as u64)
     }
 
+    #[deprecated(since = "0.4.0", note = "use RightsBuilder::allow instead")]
     pub fn add(&mut self, right: Right) -> &mut RightsBuilder {
+        self.allow(right)
+    }
+
+    pub fn allow(&mut self, right: Right) -> &mut RightsBuilder {
         self.0 |= right as u64;
         self
     }
@@ -180,7 +185,12 @@ impl RightsBuilder {
         self.0
     }
 
+    #[deprecated(since = "0.4.0", note = "use RightsBuilder::deny instead")]
     pub fn remove(&mut self, right: Right) -> &mut RightsBuilder {
+        self.deny(right)
+    }
+
+    pub fn deny(&mut self, right: Right) -> &mut RightsBuilder {
         self.0 = (self.0 & !(right as u64)) | 0x200000000000000;
         self
     }
@@ -265,6 +275,7 @@ impl FileRights {
         unsafe { libc::cap_rights_is_valid(&self.0) }
     }
 
+    /// Add all rights present in `other` to this structure.
     pub fn merge(&mut self, other: &FileRights) -> io::Result<()> {
         unsafe {
             let result = libc::cap_rights_merge(&mut self.0 as *mut cap_rights_t, &other.0);
@@ -276,6 +287,7 @@ impl FileRights {
         }
     }
 
+    /// Remove any rights present in `other` from this structure, if they are set.
     pub fn remove(&mut self, other: &FileRights) -> io::Result<()> {
         unsafe {
             let result = libc::cap_rights_remove(&mut self.0 as *mut cap_rights_t, &other.0);
@@ -287,7 +299,12 @@ impl FileRights {
         }
     }
 
+    #[deprecated(since = "0.4.0", note = "use FileRights::allow instead")]
     pub fn set(&mut self, raw_rights: Right) -> io::Result<()> {
+        self.allow(raw_rights)
+    }
+
+    pub fn allow(&mut self, raw_rights: Right) -> io::Result<()> {
         unsafe {
             let result =
                 libc::__cap_rights_set(&mut self.0 as *mut cap_rights_t, raw_rights as u64, 0u64);
@@ -299,7 +316,12 @@ impl FileRights {
         }
     }
 
+    #[deprecated(since = "0.4.0", note = "use FileRights::deny instead")]
     pub fn clear(&mut self, raw_rights: Right) -> io::Result<()> {
+        self.deny(raw_rights)
+    }
+
+    pub fn deny(&mut self, raw_rights: Right) -> io::Result<()> {
         unsafe {
             let result =
                 libc::__cap_rights_clear(&mut self.0 as *mut cap_rights_t, raw_rights as u64, 0u64);

--- a/capsicum/src/util.rs
+++ b/capsicum/src/util.rs
@@ -33,7 +33,7 @@ use libc::{c_int, c_uint, mode_t, openat};
 ///
 /// // Create the set of capabilities
 /// let rights = RightsBuilder::new(Right::Read)
-///     .add(Right::Lookup)
+///     .allow(Right::Lookup)
 ///     .finalize();
 ///
 /// // Limit the capabilities

--- a/capsicum/tests/lib.rs
+++ b/capsicum/tests/lib.rs
@@ -50,14 +50,13 @@ mod base {
     #[test]
     fn test_rights_builer() {
         let mut builder = RightsBuilder::new(Right::Read);
-        builder
-            .add(Right::Lookup)
-            .add(Right::AclSet)
-            .add(Right::AclSet)
-            .add(Right::AclGet)
-            .add(Right::Write)
-            .remove(Right::Lookup)
-            .remove(Right::AclGet);
+        let builder = builder.add(Right::Lookup);
+        let builder = builder.add(Right::AclSet);
+        let builder = builder.add(Right::AclSet);
+        let builder = builder.add(Right::AclGet);
+        let builder = builder.add(Right::Write);
+        let builder = builder.remove(Right::Lookup);
+        let builder = builder.remove(Right::AclGet);
         assert_eq!(144115188076380163, builder.raw());
     }
 

--- a/capsicum/tests/lib.rs
+++ b/capsicum/tests/lib.rs
@@ -50,13 +50,13 @@ mod base {
     #[test]
     fn test_rights_builer() {
         let mut builder = RightsBuilder::new(Right::Read);
-        let builder = builder.add(Right::Lookup);
-        let builder = builder.add(Right::AclSet);
-        let builder = builder.add(Right::AclSet);
-        let builder = builder.add(Right::AclGet);
-        let builder = builder.add(Right::Write);
-        let builder = builder.remove(Right::Lookup);
-        let builder = builder.remove(Right::AclGet);
+        let builder = builder.allow(Right::Lookup);
+        let builder = builder.allow(Right::AclSet);
+        let builder = builder.allow(Right::AclSet);
+        let builder = builder.allow(Right::AclGet);
+        let builder = builder.allow(Right::Write);
+        let builder = builder.deny(Right::Lookup);
+        let builder = builder.deny(Right::AclGet);
         assert_eq!(144115188076380163, builder.raw());
     }
 
@@ -70,9 +70,9 @@ mod base {
 
         rights.merge(&to_merge).unwrap();
 
-        rights.set(Right::Read).unwrap();
+        rights.allow(Right::Read).unwrap();
 
-        rights.clear(Right::Write).unwrap();
+        rights.deny(Right::Write).unwrap();
 
         assert!(rights.is_set(Right::Read));
 
@@ -130,9 +130,7 @@ mod base {
     #[test]
     fn test_ioctl() {
         let file = tempfile().unwrap();
-        let ioctls = IoctlsBuilder::new()
-            .add(1)
-            .finalize();
+        let ioctls = IoctlsBuilder::new().allow(1).finalize();
         ioctls.limit(&file).unwrap();
         let limited = IoctlRights::from_file(&file, 10).unwrap();
         assert_eq!(ioctls, limited);
@@ -150,8 +148,8 @@ mod base {
     fn test_fcntl() {
         let file = tempfile().unwrap();
         let fcntls = FcntlsBuilder::new()
-            .add(Fcntl::GetFL)
-            .add(Fcntl::GetOwn)
+            .allow(Fcntl::GetFL)
+            .allow(Fcntl::GetOwn)
             .finalize();
         fcntls.limit(&file).unwrap();
         let new_fcntls = FcntlRights::from_file(&file).unwrap();
@@ -180,7 +178,7 @@ mod util {
         let fname = "foo";
         fs::File::create(tdir.path().join(fname)).unwrap();
         let rights = RightsBuilder::new(Right::Read)
-            .add(Right::Lookup)
+            .allow(Right::Lookup)
             .finalize();
         rights.limit(&dir).unwrap();
         match unsafe { fork() }.unwrap() {

--- a/capsicum/tests/lib.rs
+++ b/capsicum/tests/lib.rs
@@ -131,7 +131,7 @@ mod base {
     #[test]
     fn test_ioctl() {
         let file = tempfile().unwrap();
-        let ioctls = IoctlsBuilder::new(i64::max_value() as libc::u_long)
+        let ioctls = IoctlsBuilder::new()
             .add(1)
             .finalize();
         ioctls.limit(&file).unwrap();

--- a/capsicum/tests/lib.rs
+++ b/capsicum/tests/lib.rs
@@ -149,7 +149,8 @@ mod base {
     #[test]
     fn test_fcntl() {
         let file = tempfile().unwrap();
-        let fcntls = FcntlsBuilder::new(Fcntl::GetFL)
+        let fcntls = FcntlsBuilder::new()
+            .add(Fcntl::GetFL)
             .add(Fcntl::GetOwn)
             .finalize();
         fcntls.limit(&file).unwrap();


### PR DESCRIPTION
  * They are both now `Clone`.
  * Their `new` methods no longer take arguments.  The value formerly supplied
    as an argument must now be supplied by the `add` methods.
  * `IoctlsBuilder`'s methods now pass by move.
  * The `IoctlsBuilder::raw`, `FcntlsBuilder::raw`, `IoctlRights::new`, and
    `FcntlRights::new` methods are all deprecated.

Fixes #46 