### PR TITLE
Deprecate util::Directory

### DIFF
--- a/capsicum/CHANGELOG.md
+++ b/capsicum/CHANGELOG.md
@@ -10,6 +10,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Implemented `Send` and `Sync` for `CapChannel`.
   ([#66](https://github.com/dlrobertson/capsicum-rs/pull/66))
 
+### Removed
+
+- `util::Directory` is deprecated.  Use the `cap-std` crate instead.
+  ([#74](https://github.com/dlrobertson/capsicum-rs/pull/74))
+
 ## [0.3.0] - 2023-09-21
 
 ### Changed

--- a/capsicum/Cargo.toml
+++ b/capsicum/Cargo.toml
@@ -42,6 +42,7 @@ ctor = "0.2.3"
 version_check = "0.9.4"
 
 [dev-dependencies]
+cap-std = "3.0"
 cstr = "0.2.11"
 nix = { version = "0.27.0", default_features = false, features = [ "fs", "ioctl", "process", "socket" ] }
 libnv-sys = "0.2.1"

--- a/capsicum/src/lib.rs
+++ b/capsicum/src/lib.rs
@@ -45,6 +45,27 @@
 //!
 //! assert!(ok_file.read_to_string(&mut s).is_ok());
 //! ```
+//!
+//! ## Opening new files in a subdirectory after entering capability mode
+//!
+//! ```
+//!  use std::fs::File;
+//!  use std::io::Read;
+//!
+//!  // Before entering capability mode, we can open files in the global namespace.
+//!  let aa = cap_std::ambient_authority();
+//!  let etc = cap_std::fs::Dir::open_ambient_dir("/etc", aa).unwrap();
+//!
+//!  capsicum::enter().expect("enter failed!");
+//!
+//!  // Now, we can no longer access the global file system namespace.
+//!  let aa = cap_std::ambient_authority();
+//!  cap_std::fs::Dir::open_ambient_dir("/etc", aa).unwrap_err();
+//!  std::fs::File::open("/etc/passwd").unwrap_err();
+//!
+//!  // But we can still open children of our already-open directory
+//!  let passwd = etc.open("passwd").unwrap();
+//! ```
 #[cfg(feature = "casper")]
 #[cfg_attr(docsrs, doc(cfg(feature = "casper")))]
 pub mod casper;

--- a/capsicum/src/util.rs
+++ b/capsicum/src/util.rs
@@ -1,6 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#![allow(deprecated)] // this whole file is deprecated.
 
 use std::{
     ffi::CString,
@@ -45,6 +46,7 @@ use libc::{c_int, c_uint, mode_t, openat};
 /// // within the ./src directory
 /// let fd = dir.open_file("lib.rs", 0, None).unwrap();
 /// ```
+#[deprecated(since = "0.4.0", note = "Use cap_std::fs::Dir instead")]
 pub struct Directory {
     file: File,
 }

--- a/capsicum/tests/lib.rs
+++ b/capsicum/tests/lib.rs
@@ -162,7 +162,7 @@ mod base {
 mod util {
     use std::fs;
 
-    use capsicum::{self, util::Directory, CapRights, Right, RightsBuilder};
+    use capsicum::{self, CapRights, Right, RightsBuilder};
     use nix::{
         sys::wait::{waitpid, WaitStatus},
         unistd::{fork, ForkResult},
@@ -173,9 +173,10 @@ mod util {
 
     /// We can lookup paths in a directory with Right::Lookup
     #[test]
+    #[allow(deprecated)]
     fn test_basic_dir_ok() {
         let tdir = tempdir().unwrap();
-        let dir = Directory::new(tdir.path()).unwrap();
+        let dir = capsicum::util::Directory::new(tdir.path()).unwrap();
         let fname = "foo";
         fs::File::create(tdir.path().join(fname)).unwrap();
         let rights = RightsBuilder::new(Right::Read)
@@ -198,9 +199,10 @@ mod util {
 
     /// Without Right::Lookup, looking up paths in a directory is not allowed
     #[test]
+    #[allow(deprecated)]
     fn test_basic_dir_err() {
         let tdir = tempdir().unwrap();
-        let dir = Directory::new(tdir.path()).unwrap();
+        let dir = capsicum::util::Directory::new(tdir.path()).unwrap();
         let fname = "foo";
         fs::File::create(tdir.path().join(fname)).unwrap();
         let rights = RightsBuilder::new(Right::Read).finalize();


### PR DESCRIPTION
It was a wrapper around openat.  But cap-std contains a much more complete set of wrappers around the various *at methods.  Let's use it instead of reinventing the wheel.

Fixes #62