### PR TITLE
Fix cargo audit in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,7 +63,6 @@ lint_task:
     - . $HOME/.cargo/env
     - rustup component add --toolchain $VERSION clippy
     - rustup component add --toolchain $VERSION rustfmt
-    - pkg install -y cargo-audit
   cargo_cache:
     folder: $HOME/.cargo/registry
   clippy_script:
@@ -75,5 +74,6 @@ lint_task:
     - cargo +$VERSION fmt --all -- --check --color=never
   audit_script:
     - . $HOME/.cargo/env
+    - cargo install --version=0.17.6 cargo-audit
     - cargo audit
   before_cache_script: rm -rf $CARGO_HOME/registry/index


### PR DESCRIPTION
cargo-audit 0.18.3 does not work in Cirrus's environment

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=276557 https://github.com/rustsec/rustsec/issues/1058