### PR TITLE
Document all public members

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,7 @@
 setup: &SETUP
   env:
     HOME: /tmp # cargo needs it
+    RUSTFLAGS: -D warnings
     VERSION: nightly
   setup_script:
     - pkg install -y llvm

--- a/capsicum/CHANGELOG.md
+++ b/capsicum/CHANGELOG.md
@@ -45,6 +45,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - `RightsBuilder::raw` is removed and `FileRights::new` is deprecated.
   ([#80](https://github.com/dlrobertson/capsicum-rs/pull/80))
 
+- `FileRights::is_valid` is deprecated, because it is no longer useful without
+  `FileRights::new`.
+  ([#81](https://github.com/dlrobertson/capsicum-rs/pull/81))
+
 - `util::Directory` is deprecated.  Use the `cap-std` crate instead.
   ([#74](https://github.com/dlrobertson/capsicum-rs/pull/74))
 

--- a/capsicum/src/lib.rs
+++ b/capsicum/src/lib.rs
@@ -1,6 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#![warn(missing_docs)]
 
 //! ## Entering capability mode
 //!


### PR DESCRIPTION
Also, deprecate FileRights::is_valid, which should no longer be necessary after #80.