### PR TITLE
Casper::{service_open, try_clone} must take &mut self

### DIFF
--- a/capsicum/examples/getuid.rs
+++ b/capsicum/examples/getuid.rs
@@ -74,7 +74,7 @@ impl CapAgent {
 
 fn main() {
     // Safe because we're still single-threaded
-    let casper = unsafe { Casper::new().unwrap() };
+    let mut casper = unsafe { Casper::new().unwrap() };
     capsicum::enter().unwrap();
 
     let mut cap_uid = casper.uid().unwrap();


### PR DESCRIPTION
Because internally, within the C library, they use nvlist_xfer.  That sends an nvlist to the Casper daemon and retrives one in return.  So they must use synchronization when called from multiple threads, so that threads' responses don't get interleaved.

No CHANGELOG entry necessary because prior to PR #66 it was impossible to use these functions from multiple threads anyway.

See https://reviews.freebsd.org/D42928