### PR TITLE
Add the "links" property to casper-sys's Cargo.toml

### DIFF
--- a/casper-sys/Cargo.toml
+++ b/casper-sys/Cargo.toml
@@ -6,13 +6,12 @@ authors = ["Alan Somers <asomers@gmail.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/dlrobertson/capsicum-rs"
 rust-version = "1.62"
+categories = ["external-ffi-bindings"]
 description = """
 FFI bindings for FreeBSD's libcasper
 """
 keywords = ["sandbox", "FreeBSD", "capsicum"]
-
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+links = "casper"
 
 [dependencies]
 libnv-sys = "0.2.1"


### PR DESCRIPTION
To prevent two crates from linking to the same C library, which can cause havoc.  Also, add a Cargo category.

Reported by:	lib.rs maintainer dashboard