### PR TITLE
Deprecate FcntlsBuilder and RightsBuilder

### DIFF
--- a/capsicum/CHANGELOG.md
+++ b/capsicum/CHANGELOG.md
@@ -18,26 +18,25 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Renamed `Right::Renameat` to `Right::RenameatSource`.
   ([#85](https://github.com/dlrobertson/capsicum-rs/pull/85))
 
-- The `IoctlsBuilder` and `FcntlsBuilder` APIs have the following changes:
-  * They are both now `Clone`.
-  * Their `new` methods no longer take arguments.  The value formerly supplied
-    as an argument must now be supplied by the `add` methods.
+- The `IoctlsBuilder`, `FcntlsBuilder`, and `RightsBuilder` structs have been
+  heavily changed:
+  * `FcntlsBuilder` and `RightsBuilder` are deprecated.  You may now use
+    `FcntlRights` and `FileRights` directly.
+  * Unlike the builder structs old `new` methods, `FcntlRights`'s and
+    `FileRights`'s new methods take no arguments.  The values formerly supplied
+    as arguments to `new` must now be provided to the `allow` methods.
+  * `FcntlRights` and `FileRights` are now `Copy` and `Clone`.
+  * `IoctlsBuilder` is now `Clone`.
   * `IoctlsBuilder`'s methods now pass by move.
-  * The `IoctlsBuilder::raw`, `FcntlsBuilder::raw`, `IoctlRights::new`, and
-    `FcntlRights::new` methods are all deprecated.
-  * Their `add` and `remove` methods have been renamed to `allow`/`deny`,
-    respectively.
+  * `IoctlsBuilder::raw` and `IoctlRights::new` methods are deprecated.
+  * `IoctlsBuilder`'s `add` and `remove` methods have been renamed to
+    `allow`/`deny`, respectively.  Similarly named methods are added to
+    `FileRights` and `FcntlRights`.  `FileRights`'s `set`/`clear` methods are
+    similarly deprecated.
   ([#71](https://github.com/dlrobertson/capsicum-rs/pull/71))
+  ([#88](https://github.com/dlrobertson/capsicum-rs/pull/88))
 
-- The `RightsBuilder`'s `add`/`remove` methods have been renamed to
-  `allow`/`deny`, respectively.  Also, `FileRights`'s `set`/`clear` methods
-  have been renamed to `allow`/`deny`.
-  ([#71](https://github.com/dlrobertson/capsicum-rs/pull/71))
-
-- More changes to `RightsBuilder`.
-  * The `new` method no longer takes an argument.
-  * `Rights` are now `Clone`, `Copy`, and `Eq`.
-  * `RightsBuilder` is now `Clone`.
+- `Rights` are now `Clone`, `Copy`, and `Eq`.
   ([#80](https://github.com/dlrobertson/capsicum-rs/pull/80))
 
 ### Fixed
@@ -48,11 +47,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Removed
 
-- `RightsBuilder::raw` is removed and `FileRights::new` is deprecated.
+- `RightsBuilder::raw` is removed.
   ([#80](https://github.com/dlrobertson/capsicum-rs/pull/80))
 
 - `FileRights::is_valid` is deprecated, because it is no longer useful without
-  `FileRights::new`.
+  the new argument-less `FileRights::new`.
   ([#81](https://github.com/dlrobertson/capsicum-rs/pull/81))
 
 - `util::Directory` is deprecated.  Use the `cap-std` crate instead.

--- a/capsicum/src/lib.rs
+++ b/capsicum/src/lib.rs
@@ -30,16 +30,15 @@
 //! ## Limit capability rights to files
 //!
 //! ```
-//! use capsicum::{CapRights, Right, RightsBuilder};
+//! use capsicum::{CapRights, Right, FileRights};
 //! use std::fs::File;
 //! use std::io::Read;
 //! let mut ok_file = File::open("/etc/passwd").unwrap();
 //! let mut s = String::new();
 //!
-//! RightsBuilder::new()
+//! FileRights::new()
 //!     .allow(Right::Seek)
 //!     .allow(Right::Read)
-//!     .finalize()
 //!     .limit(&ok_file).unwrap();
 //!
 //! assert!(ok_file.read_to_string(&mut s).is_ok());
@@ -76,9 +75,13 @@ mod right;
 /// Deprecated utilities
 pub mod util;
 
-pub use fcntl::{Fcntl, FcntlRights, FcntlsBuilder};
+#[allow(deprecated)]
+pub use fcntl::FcntlsBuilder;
+pub use fcntl::{Fcntl, FcntlRights};
 pub use ioctl::{IoctlRights, IoctlsBuilder};
 pub use process::{enter, get_mode, sandboxed};
-pub use right::{FileRights, Right, RightsBuilder};
+#[allow(deprecated)]
+pub use right::RightsBuilder;
+pub use right::{FileRights, Right};
 
 pub use crate::common::CapRights;

--- a/capsicum/src/right.rs
+++ b/capsicum/src/right.rs
@@ -168,9 +168,11 @@ impl Right {
 ///     .allow(Right::Fexecve)
 ///     .finalize();
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+#[deprecated(since = "0.4.0", note = "Use FcntlRights directly")]
 pub struct RightsBuilder(cap_rights_t);
 
+#[allow(deprecated)]
 impl RightsBuilder {
     /// Initialize a new `RightsBuilder` which will deny all rights.
     pub fn new() -> RightsBuilder {
@@ -225,6 +227,7 @@ impl RightsBuilder {
     }
 }
 
+#[allow(deprecated)]
 impl Default for RightsBuilder {
     fn default() -> Self {
         RightsBuilder::new()
@@ -241,14 +244,12 @@ impl Default for RightsBuilder {
 /// ```
 /// # use std::os::unix::io::AsRawFd;
 /// # use std::io::{self, Read, Write};
-/// # use capsicum::{CapRights, RightsBuilder, Right};
+/// # use capsicum::{CapRights, FileRights, Right};
 /// # use tempfile::tempfile;
 /// let mut file = tempfile().unwrap();
-/// let rights = RightsBuilder::new()
+/// FileRights::new()
 ///     .allow(Right::Read)
-///     .finalize();
-///
-/// rights.limit(&file).unwrap();
+///     .limit(&file).unwrap();
 ///
 /// capsicum::enter().unwrap();
 ///
@@ -258,27 +259,20 @@ impl Default for RightsBuilder {
 /// let e = file.write(&buf[..]).unwrap_err();
 /// assert_eq!(e.raw_os_error(), Some(libc::ENOTCAPABLE));
 /// ```
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FileRights(cap_rights_t);
 
 impl FileRights {
-    // Deprecate because it's unsafe.  The assertion will fail for some inputs.
-    #[deprecated(since = "0.4.0", note = "use RightsBuilder instead")]
-    #[allow(missing_docs)]
-    pub fn new(raw_rights: u64) -> FileRights {
+    /// Initialize a new `FileRights` which will deny all rights.
+    pub fn new() -> Self {
         // cap_rights_init is documented as infalliable.
         let inner_rights = unsafe {
             let mut inner_rights = mem::zeroed();
-            libc::__cap_rights_init(
-                RIGHTS_VERSION,
-                &mut inner_rights as *mut cap_rights_t,
-                raw_rights,
-                0u64,
-            );
+            libc::__cap_rights_init(RIGHTS_VERSION, &mut inner_rights as *mut cap_rights_t, 0u64);
             inner_rights
         };
-        let rights = FileRights(inner_rights);
-        assert!(rights.is_valid_priv());
+        let rights = Self(inner_rights);
+        debug_assert!(rights.is_valid_priv());
         rights
     }
 
@@ -290,14 +284,13 @@ impl FileRights {
     /// # Example
     /// ```
     /// # use std::os::unix::io::AsRawFd;
-    /// # use capsicum::{CapRights, RightsBuilder, FileRights, Right};
+    /// # use capsicum::{CapRights, FileRights, Right};
     /// # use tempfile::tempfile;
     /// use nix::errno::Errno;
     /// use nix::fcntl::{FcntlArg, OFlag, fcntl};
     /// let file = tempfile().unwrap();
-    /// let rights = RightsBuilder::new()
-    ///     .allow(Right::Read)
-    ///     .finalize();
+    /// let mut rights = FileRights::new();
+    /// rights.allow(Right::Read);
     ///
     /// rights.limit(&file).unwrap();
     /// let rights2 = FileRights::from_file(&file).unwrap();
@@ -324,24 +317,28 @@ impl FileRights {
         Ok(rights)
     }
 
+    /// Add a new `Right` to the list of allowed rights.
+    pub fn allow(&mut self, right: Right) -> &mut Self {
+        let result = unsafe { libc::__cap_rights_set(self.as_mut_ptr(), right as u64, 0u64) };
+        debug_assert!(!result.is_null()); // documented as infalliable
+        self
+    }
+
     /// Checks if `self` contains all of the rights present in `other`.
     ///
     /// # Example
     /// ```
-    /// # use capsicum::{CapRights, RightsBuilder, FileRights, Right};
-    /// let rights1 = RightsBuilder::new()
-    ///     .allow(Right::Read)
-    ///     .allow(Right::Write)
-    ///     .finalize();
-    /// let rights2 = RightsBuilder::new()
-    ///     .allow(Right::Write)
-    ///     .finalize();
+    /// # use capsicum::{CapRights, FileRights, Right};
+    /// let mut rights1 = FileRights::new();
+    /// rights1.allow(Right::Read);
+    /// rights1.allow(Right::Write);
+    /// let mut rights2 = FileRights::new();
+    /// rights2.allow(Right::Write);
     /// assert!(rights1.contains(&rights2));
     ///
-    /// let rights3 = RightsBuilder::new()
-    ///     .allow(Right::Read)
-    ///     .allow(Right::Seek)
-    ///     .finalize();
+    /// let mut rights3 = FileRights::new();
+    /// rights3.allow(Right::Read);
+    /// rights3.allow(Right::Seek);
     /// assert!(!rights1.contains(&rights3));
     /// ```
     pub fn contains(&self, other: &FileRights) -> bool {
@@ -352,11 +349,10 @@ impl FileRights {
     ///
     /// # Example
     /// ```
-    /// # use capsicum::{Right, RightsBuilder, FileRights};
+    /// # use capsicum::{Right, FileRights};
     ///
-    /// let rights = RightsBuilder::new()
-    ///     .allow(Right::Read)
-    ///     .finalize();
+    /// let mut rights = FileRights::new();
+    /// rights.allow(Right::Read);
     /// assert!(rights.is_set(Right::Read));
     /// assert!(!rights.is_set(Right::Write));
     /// ```
@@ -401,37 +397,28 @@ impl FileRights {
     #[allow(missing_docs)]
     #[deprecated(since = "0.4.0", note = "use FileRights::allow instead")]
     pub fn set(&mut self, raw_rights: Right) -> io::Result<()> {
-        self.allow(raw_rights)
-    }
-
-    /// Add another `Right` to the list that will be allowed.
-    pub fn allow(&mut self, right: Right) -> io::Result<()> {
-        unsafe {
-            let result = libc::__cap_rights_set(self.as_mut_ptr(), right as u64, 0u64);
-            if result.is_null() {
-                Err(io::Error::last_os_error())
-            } else {
-                Ok(())
-            }
-        }
+        self.allow(raw_rights);
+        Ok(())
     }
 
     #[allow(missing_docs)]
     #[deprecated(since = "0.4.0", note = "use FileRights::deny instead")]
     pub fn clear(&mut self, raw_rights: Right) -> io::Result<()> {
-        self.deny(raw_rights)
+        self.deny(raw_rights);
+        Ok(())
     }
 
     /// Remove an allowed `Right` from the list.
-    pub fn deny(&mut self, right: Right) -> io::Result<()> {
-        unsafe {
-            let result = libc::__cap_rights_clear(self.as_mut_ptr(), right as u64, 0u64);
-            if result.is_null() {
-                Err(io::Error::last_os_error())
-            } else {
-                Ok(())
-            }
-        }
+    pub fn deny(&mut self, right: Right) -> &mut Self {
+        let result = unsafe { libc::__cap_rights_clear(self.as_mut_ptr(), right as u64, 0u64) };
+        debug_assert!(!result.is_null()); // documented as infalliable
+        self
+    }
+}
+
+impl Default for FileRights {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/capsicum/src/util.rs
+++ b/capsicum/src/util.rs
@@ -25,20 +25,17 @@ use libc::{c_int, c_uint, mode_t, openat};
 /// # Examples
 ///
 /// ```
-/// use capsicum::{self, CapRights, Right, RightsBuilder};
+/// use capsicum::{self, CapRights, Right, FileRights};
 /// use capsicum::util::Directory;
 ///
 /// // Open the directory
 /// let dir = Directory::new("./src").unwrap();
 ///
-/// // Create the set of capabilities
-/// let rights = RightsBuilder::new()
+/// // Limit the capabilities of the open directory
+/// FileRights::new()
 ///     .allow(Right::Read)
 ///     .allow(Right::Lookup)
-///     .finalize();
-///
-/// // Limit the capabilities
-/// rights.limit(&dir).unwrap();
+///     .limit(&dir).unwrap();
 ///
 /// // Enter the sandbox
 /// capsicum::enter().unwrap();


### PR DESCRIPTION
They never offered any real advantage over using FcntlsRights and FileRights directly, other than providing symmetry with IoctlsBuilder.