### PR TITLE
Use native cstr literals instead of the cstr crate

### DIFF
--- a/capsicum/Cargo.toml
+++ b/capsicum/Cargo.toml
@@ -43,7 +43,6 @@ version_check = "0.9.4"
 
 [dev-dependencies]
 cap-std = "3.0"
-cstr = "0.2.11"
 nix = { version = "0.27.0", default-features = false, features = [ "fs", "ioctl", "process", "socket" ] }
 libnv-sys = "0.2.1"
 tempfile = "3.0"

--- a/capsicum/examples/getuid.rs
+++ b/capsicum/examples/getuid.rs
@@ -4,13 +4,12 @@
 use std::{ffi::CStr, io};
 
 use capsicum::casper::{self, Casper, NvError, NvFlag, NvList, ServiceRegisterFlags};
-use cstr::cstr;
 use libc::uid_t;
 
 /// The Capser `uid` helper process.
 struct CapUid {}
 impl casper::Service for CapUid {
-    const SERVICE_NAME: &'static CStr = cstr!("getuid");
+    const SERVICE_NAME: &'static CStr = c"getuid";
 
     fn cmd(
         cmd: &str,
@@ -27,7 +26,7 @@ impl casper::Service for CapUid {
 
         // This C function is always safe
         let uid = unsafe { libc::getuid() };
-        nvout.insert_number(cstr!("uid"), uid).unwrap();
+        nvout.insert_number(c"uid", uid).unwrap();
         Ok(())
     }
 
@@ -48,9 +47,9 @@ impl CapAgent {
     // `getuid` works fine in capability mode, but it's a nice simple demo.
     pub fn uid(&mut self) -> io::Result<uid_t> {
         let mut invl = NvList::new(NvFlag::None).unwrap();
-        invl.insert_string(cstr!("cmd"), cstr!("getuid")).unwrap();
+        invl.insert_string(c"cmd", c"getuid").unwrap();
         let onvl = self.xfer_nvlist(invl)?;
-        match onvl.get_number(cstr!("uid")) {
+        match onvl.get_number(c"uid") {
             Ok(Some(uid)) => Ok(uid as uid_t),
             Ok(None) => panic!("zygote did not return the expected value"),
             Err(NvError::NativeError(e)) => Err(io::Error::from_raw_os_error(e)),

--- a/capsicum/src/casper/mod.rs
+++ b/capsicum/src/casper/mod.rs
@@ -158,11 +158,10 @@ mod macros {
     /// # Examples
     /// ```
     /// use capsicum::casper;
-    /// use cstr::cstr;
     ///
     /// casper::service_connection!(
     ///     pub CapGroupAgent,
-    ///     cstr!("system.grp"),
+    ///     c"system.grp",
     ///     group
     /// );
     /// ```
@@ -267,11 +266,10 @@ mod macros {
     /// # use std::{ffi::CStr, io};
     /// # use libnv::libnv::NvList;
     /// use capsicum::casper;
-    /// use cstr::cstr;
     ///
     /// struct CapUid {}
     /// impl casper::Service for CapUid {
-    /// # const SERVICE_NAME: &'static CStr = cstr!("getuid");
+    /// # const SERVICE_NAME: &'static CStr = c"getuid";
     /// # fn cmd(_: &str, _: Option<&NvList>, _: Option<&mut NvList>, _: &mut NvList) -> io::Result<()> {
     /// # unimplemented!()
     /// # }


### PR DESCRIPTION
This is a new feature in Rust 1.77.0, which is already our MSRV.