### PR TITLE
Use I/O Safety

### DIFF
--- a/capsicum/CHANGELOG.md
+++ b/capsicum/CHANGELOG.md
@@ -16,6 +16,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Implemented `Send` and `Sync` for `CapChannel`.
   ([#66](https://github.com/dlrobertson/capsicum-rs/pull/66))
 
+- `util::Directory` now implements `AsFd`.
+  ([#98](https://github.com/dlrobertson/capsicum-rs/pull/98))
+
 ### Changed
 
 - The `Casper::service_open` function (usually called via the `service!` and
@@ -50,6 +53,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - `Rights` are now `Clone`, `Copy`, and `Eq`.
   ([#80](https://github.com/dlrobertson/capsicum-rs/pull/80))
+
+- `CapRights::limit`, `FcntlRights::from_file`, `IoctlRights::from_file`, and
+  `FileRights::from_file` now take `AsFd` arguments instead of `AsRawFd`.
+  ([#98](https://github.com/dlrobertson/capsicum-rs/pull/98))
 
 ### Fixed
 

--- a/capsicum/Cargo.toml
+++ b/capsicum/Cargo.toml
@@ -43,6 +43,6 @@ version_check = "0.9.4"
 
 [dev-dependencies]
 cap-std = "3.0"
-nix = { version = "0.27.0", default-features = false, features = [ "fs", "ioctl", "process", "socket" ] }
+nix = { version = ">=0.27.0,<0.30.0", default-features = false, features = [ "fs", "ioctl", "process", "socket" ] }
 libnv-sys = "0.2.1"
 tempfile = "3.0"

--- a/capsicum/Cargo.toml
+++ b/capsicum/Cargo.toml
@@ -45,4 +45,4 @@ version_check = "0.9.4"
 cap-std = "3.0"
 nix = { version = ">=0.27.0,<0.30.0", default-features = false, features = [ "fs", "ioctl", "process", "socket" ] }
 libnv-sys = "0.2.1"
-tempfile = "3.0"
+tempfile = "3.6"

--- a/capsicum/src/common.rs
+++ b/capsicum/src/common.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::{io, os::unix::io::AsRawFd};
+use std::{io, os::unix::io::AsFd};
 
 /// A set of capabilities that may be restricted on file descriptors.
 pub trait CapRights: Sized {
@@ -10,5 +10,5 @@ pub trait CapRights: Sized {
     ///
     /// When a file descriptor is first created, it is assigned all possible capability rights.
     /// Those rights may be reduced (but never expanded), by this method.
-    fn limit<T: AsRawFd>(&self, fd: &T) -> io::Result<()>;
+    fn limit<F: AsFd>(&self, f: &F) -> io::Result<()>;
 }

--- a/capsicum/src/right.rs
+++ b/capsicum/src/right.rs
@@ -291,8 +291,6 @@ impl FileRights {
     /// # use std::os::unix::io::AsRawFd;
     /// # use capsicum::{CapRights, FileRights, Right};
     /// # use tempfile::tempfile;
-    /// use nix::errno::Errno;
-    /// use nix::fcntl::{FcntlArg, OFlag, fcntl};
     /// let file = tempfile().unwrap();
     /// let mut rights = FileRights::new();
     /// rights.allow(Right::Read);

--- a/capsicum/src/right.rs
+++ b/capsicum/src/right.rs
@@ -11,6 +11,7 @@ use std::{
     mem,
     ops::BitAnd,
     os::{
+        fd::AsFd,
         raw::c_char,
         unix::io::{AsRawFd, RawFd},
     },
@@ -247,7 +248,6 @@ impl Default for RightsBuilder {
 ///
 /// # Example
 /// ```
-/// # use std::os::unix::io::AsRawFd;
 /// # use std::io::{self, Read, Write};
 /// # use capsicum::{CapRights, FileRights, Right};
 /// # use tempfile::tempfile;
@@ -288,7 +288,6 @@ impl FileRights {
     /// Retrieve the list of rights currently allowed for the given file.
     /// # Example
     /// ```
-    /// # use std::os::unix::io::AsRawFd;
     /// # use capsicum::{CapRights, FileRights, Right};
     /// # use tempfile::tempfile;
     /// let file = tempfile().unwrap();
@@ -302,14 +301,12 @@ impl FileRights {
     ///
     /// # See Also
     /// [`cap_rights_get(3)`](https://www.freebsd.org/cgi/man.cgi?query=cap_rights_get)
-    pub fn from_file<T: AsRawFd>(fd: &T) -> io::Result<FileRights> {
+    pub fn from_file<F: AsFd>(f: &F) -> io::Result<FileRights> {
+        let fd = f.as_fd().as_raw_fd();
         let inner_rights = unsafe {
             let mut inner_rights = unsafe { mem::zeroed() };
-            let res = libc::__cap_rights_get(
-                RIGHTS_VERSION,
-                fd.as_raw_fd(),
-                &mut inner_rights as *mut cap_rights_t,
-            );
+            let res =
+                libc::__cap_rights_get(RIGHTS_VERSION, fd, &mut inner_rights as *mut cap_rights_t);
             if res < 0 {
                 return Err(io::Error::last_os_error());
             }
@@ -426,9 +423,10 @@ impl Default for FileRights {
 }
 
 impl CapRights for FileRights {
-    fn limit<T: AsRawFd>(&self, fd: &T) -> io::Result<()> {
+    fn limit<F: AsFd>(&self, f: &F) -> io::Result<()> {
+        let fd = f.as_fd().as_raw_fd();
         unsafe {
-            let res = libc::cap_rights_limit(fd.as_raw_fd(), &self.0 as *const cap_rights_t);
+            let res = libc::cap_rights_limit(fd, &self.0 as *const cap_rights_t);
             if res < 0 {
                 Err(io::Error::last_os_error())
             } else {

--- a/capsicum/src/util.rs
+++ b/capsicum/src/util.rs
@@ -7,9 +7,12 @@ use std::{
     ffi::CString,
     fs::File,
     io::{self, ErrorKind},
-    os::unix::{
-        ffi::OsStrExt,
-        io::{AsRawFd, FromRawFd, RawFd},
+    os::{
+        fd::{AsFd, BorrowedFd},
+        unix::{
+            ffi::OsStrExt,
+            io::{AsRawFd, FromRawFd, RawFd},
+        },
     },
     path::Path,
 };
@@ -86,6 +89,12 @@ impl FromRawFd for Directory {
         Directory {
             file: File::from_raw_fd(fd),
         }
+    }
+}
+
+impl AsFd for Directory {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.file.as_fd()
     }
 }
 


### PR DESCRIPTION
Functions that previously took an AsRawFd argument now take an AsFd.
There's no real improvement in I/O Safety since no capsicum function
ever stored a RawFd anywhere.  This is mostly just for style.
    
Fixes #31