### PR TITLE
Fix building the docs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -81,3 +81,19 @@ lint_task:
     - cargo update -Zdirect-minimal-versions
     - cargo check --all-features --all-targets --all
   before_cache_script: rm -rf $CARGO_HOME/registry/index
+
+# Ensure that the docs can be cross-compiled, as docs.rs does.
+task:
+  name: Cross docs
+  container:
+    image: rustlang/rust:nightly
+  cargo_cache:
+    folder: $HOME/.cargo/registry
+    fingerprint_script: cat Cargo.lock || echo ""
+  env:
+    RUSTFLAGS: --cfg docsrs
+    RUSTDOCFLAGS: --cfg docsrs
+  doc_script:
+    - rustup target add x86_64-unknown-freebsd
+    - cargo doc --target x86_64-unknown-freebsd --no-deps --all-features
+  before_cache_script: rm -rf $HOME/.cargo/registry/index

--- a/capsicum/CHANGELOG.md
+++ b/capsicum/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+### Fixed
+
+- Fixed cross-compiling the docs.
+  ([#103](https://github.com/dlrobertson/capsicum-rs/pull/103))
+
 ## [0.4.1] - 2024-06-04
 
 ### Fixed

--- a/capsicum/src/lib.rs
+++ b/capsicum/src/lib.rs
@@ -64,6 +64,8 @@
 //!  // But we can still open children of our already-open directory
 //!  let passwd = etc.open("passwd").unwrap();
 //! ```
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 #[cfg(feature = "casper")]
 #[cfg_attr(docsrs, doc(cfg(feature = "casper")))]
 pub mod casper;


### PR DESCRIPTION
They were broken on docs.rs due to using the unstable doc_cfg feature. I do not know why docs.rs successfully built version 0.3.0.

Also, add a CI task to ensure that the docs continue to cross-compile successfully.