### PR TITLE
Deprecated the `Right::CAP_ALL*` and `Right::CAP_UNUSED*` constants

### DIFF
--- a/capsicum/CHANGELOG.md
+++ b/capsicum/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+### Removed
+
+- Deprecated the `Right::CAP_ALL*` and `Right::CAP_UNUSED*` constants, because
+  they aren't stable across different OS versions, and they probably never had
+  any legitimate use in our consumers anyway.
+  ([#109](https://github.com/dlrobertson/capsicum-rs/pull/109))
+
 ## [0.4.3] - 2024-10-14
 
 ### Fixed

--- a/capsicum/Cargo.toml
+++ b/capsicum/Cargo.toml
@@ -36,7 +36,7 @@ libc = { version = "0.2.156", features = [ "extra_traits" ] }
 casper-sys = { path = "../casper-sys", optional = true, version = "0.1.2" }
 libnv = { version = "0.4.2", default-features = false, features = [ "libnv" ], optional = true }
 libnv-sys = { version = "0.2.1", optional = true }
-ctor = "0.2.3"
+ctor = "0.2.9"
 
 [build-dependencies]
 version_check = "0.9.4"

--- a/capsicum/src/right.rs
+++ b/capsicum/src/right.rs
@@ -87,8 +87,14 @@ pub enum Right {
     LinkatSource = libc::CAP_LINKAT_SOURCE,
     SockClient = libc::CAP_SOCK_CLIENT,
     SockServer = libc::CAP_SOCK_SERVER,
+    #[deprecated(since = "0.4.4", note = "May change in later OS versions")]
+    #[allow(deprecated)]
     All0 = libc::CAP_ALL0,
+    #[deprecated(since = "0.4.4", note = "May disappear in later OS versions")]
+    #[allow(deprecated)]
     Unused044 = libc::CAP_UNUSED0_44,
+    #[deprecated(since = "0.4.4", note = "May disappear in later OS versions")]
+    #[allow(deprecated)]
     Unused057 = libc::CAP_UNUSED0_57,
     MacGet = libc::CAP_MAC_GET,
     MacSet = libc::CAP_MAC_SET,
@@ -112,8 +118,14 @@ pub enum Right {
     AclSet = libc::CAP_ACL_SET,
     KqueueChange = libc::CAP_KQUEUE_CHANGE,
     Kqueue = libc::CAP_KQUEUE,
+    #[deprecated(since = "0.4.4", note = "May change in later OS versions")]
+    #[allow(deprecated)]
     All1 = libc::CAP_ALL1,
+    #[deprecated(since = "0.4.4", note = "May disappear in later OS versions")]
+    #[allow(deprecated)]
     Unused122 = libc::CAP_UNUSED1_22,
+    #[deprecated(since = "0.4.4", note = "May disappear in later OS versions")]
+    #[allow(deprecated)]
     Unused157 = libc::CAP_UNUSED1_57,
 }
 


### PR DESCRIPTION
They aren't stable across different OS versions, and they probably never had any legitimate use in our consumers anyway.