### PR TITLE
Clippy cleanup

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,16 +21,13 @@ task:
         image: freebsd-14-1-release-amd64-ufs
     - name: FreeBSD 14 amd64 stable
       env:
-        VERSION: 1.77.0
+        VERSION: 1.81.0
       freebsd_instance:
         image: freebsd-14-1-release-amd64-ufs
     - name: FreeBSD 14 i686 nightly
       # Test i686 FreeBSD in 32-bit emulation on a 64-bit host.
       env:
         TARGET: i686-unknown-freebsd
-        # Can't use nightly on i686 due to
-        # https://github.com/rust-lang/rust/issues/130677
-        VERSION: 1.77.0
       freebsd_instance:
         image: freebsd-14-1-release-amd64-ufs
   << : *SETUP

--- a/capsicum/CHANGELOG.md
+++ b/capsicum/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+### Changed
+
+- Raised the MSRV to 1.81.0
+  ([#111](https://github.com/dlrobertson/capsicum-rs/pull/111))
+
 ## [0.4.4] - 2024-12-08
 
 ### Removed

--- a/capsicum/Cargo.toml
+++ b/capsicum/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.4.4"
 authors = ["Dan Robertson <dan@dlrobertson.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/dlrobertson/capsicum-rs"
-rust-version = "1.77.0"
+rust-version = "1.81.0"
 description = """
 Simple intuitive Rust bindings for the FreeBSD capsicum framework
 """

--- a/capsicum/src/lib.rs
+++ b/capsicum/src/lib.rs
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #![warn(missing_docs)]
+// This lint is unhelpful.  See
+// https://github.com/rust-lang/rust-clippy/discussions/14256
+#![allow(clippy::doc_overindented_list_items)]
 
 //! ## Entering capability mode
 //!

--- a/capsicum/src/util.rs
+++ b/capsicum/src/util.rs
@@ -6,7 +6,7 @@
 use std::{
     ffi::CString,
     fs::File,
-    io::{self, ErrorKind},
+    io,
     os::{
         fd::{AsFd, BorrowedFd},
         unix::{
@@ -69,7 +69,7 @@ impl Directory {
         mode: Option<mode_t>,
     ) -> io::Result<File> {
         let p = CString::new(path.as_ref().as_os_str().as_bytes())
-            .or(Err(io::Error::new(ErrorKind::Other, "not a valid C path")))?;
+            .or(Err(io::Error::other("not a valid C path")))?;
         unsafe {
             let fd = match mode {
                 Some(mode) => openat(self.file.as_raw_fd(), p.as_ptr(), flags, mode as c_uint),


### PR DESCRIPTION
* Suppress the unhelpful doc_overindented_list_items lint
* Fix io_other_error by using std::io::Error::Other, introduced in Rust 1.74.0 .