### PR TITLE
Raise the libnv dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,15 @@ jobs:
       matrix:
         include:
           - freebsd_version: "14.4"
-            rust_version: "1.81.0"
+            rust_version: "1.82.0"
             target: x86_64-unknown-freebsd
             arch: x86_64
           - freebsd_version: "15.0"
-            rust_version: "1.81.0"
+            rust_version: "1.82.0"
             target: x86_64-unknown-freebsd
             arch: x86_64
           - freebsd_version: "15.0"
-            rust_version: "1.81.0"
+            rust_version: "1.82.0"
             target: i686-unknown-freebsd
             arch: i686
           - freebsd_version: "15.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
             target: x86_64-unknown-freebsd
             arch: x86_64
           - freebsd_version: "15.0"
-            rust_version: "1.82.0"
+            # Can't use Rust 1.82.0 on i686 due to a libc bug:
+            # https://github.com/rust-lang/rust/issues/130677
+            rust_version: "1.83.0"
             target: i686-unknown-freebsd
             arch: i686
           - freebsd_version: "15.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         shell: freebsd {0}
         run: |
-          pkg install -y curl llvm
+          pkg install -y curl
           fetch https://sh.rustup.rs -o rustup.sh
           sh rustup.sh -y --profile=minimal --default-toolchain ${{ matrix.rust_version }}
       - name: Setup

--- a/capsicum/CHANGELOG.md
+++ b/capsicum/CHANGELOG.md
@@ -7,8 +7,16 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- The crate can now be build without llvm being installed.
+  ([#119](https://github.com/dlrobertson/capsicum-rs/pull/119))
+
 - Raised the MSRV to 1.81.0
   ([#111](https://github.com/dlrobertson/capsicum-rs/pull/111))
+
+### Removed
+
+- Removed support for FreeBSD 13.
+  ([#119](https://github.com/dlrobertson/capsicum-rs/pull/119))
 
 ## [0.4.4] - 2024-12-08
 

--- a/capsicum/CHANGELOG.md
+++ b/capsicum/CHANGELOG.md
@@ -10,8 +10,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - The crate can now be build without llvm being installed.
   ([#119](https://github.com/dlrobertson/capsicum-rs/pull/119))
 
-- Raised the MSRV to 1.81.0
+- Raised the MSRV to 1.82.0
   ([#111](https://github.com/dlrobertson/capsicum-rs/pull/111))
+  ([#119](https://github.com/dlrobertson/capsicum-rs/pull/119))
 
 ### Removed
 

--- a/capsicum/Cargo.toml
+++ b/capsicum/Cargo.toml
@@ -34,8 +34,8 @@ path = "examples/getuid.rs"
 [dependencies]
 libc = { version = "0.2.156", features = [ "extra_traits" ] }
 casper-sys = { path = "../casper-sys", optional = true, version = "0.1.2" }
-libnv = { version = "0.4.2", default-features = false, features = [ "libnv" ], optional = true }
-libnv-sys = { version = "0.2.1", optional = true }
+libnv = { version = "0.5.0", default-features = false, features = [ "libnv" ], optional = true }
+libnv-sys = { version = "0.3.0", optional = true }
 ctor = "0.2.9"
 
 [build-dependencies]
@@ -44,5 +44,5 @@ version_check = "0.9.4"
 [dev-dependencies]
 cap-std = "3.0"
 nix = { version = ">=0.27.0,<0.30.0", default-features = false, features = [ "fs", "ioctl", "process", "socket" ] }
-libnv-sys = "0.2.1"
+libnv-sys = "0.3.0"
 tempfile = "3.6"

--- a/capsicum/Cargo.toml
+++ b/capsicum/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.4.4"
 authors = ["Dan Robertson <dan@dlrobertson.com>"]
 license = "MPL-2.0"
 repository = "https://github.com/dlrobertson/capsicum-rs"
-rust-version = "1.81.0"
+rust-version = "1.82.0"
 description = """
 Simple intuitive Rust bindings for the FreeBSD capsicum framework
 """

--- a/capsicum/Cargo.toml
+++ b/capsicum/Cargo.toml
@@ -34,8 +34,8 @@ path = "examples/getuid.rs"
 [dependencies]
 libc = { version = "0.2.156", features = [ "extra_traits" ] }
 casper-sys = { path = "../casper-sys", optional = true, version = "0.1.2" }
-libnv = { version = "0.5.0", default-features = false, features = [ "libnv" ], optional = true }
-libnv-sys = { version = "0.3.0", optional = true }
+libnv = { version = "0.5.1", default-features = false, features = [ "libnv" ], optional = true }
+libnv-sys = { version = "0.3.1", optional = true }
 ctor = "0.2.9"
 
 [build-dependencies]

--- a/casper-sys/Cargo.toml
+++ b/casper-sys/Cargo.toml
@@ -19,4 +19,4 @@ targets = [
 ]
 
 [dependencies]
-libnv-sys = "0.3.0"
+libnv-sys = "0.3.1"

--- a/casper-sys/Cargo.toml
+++ b/casper-sys/Cargo.toml
@@ -19,4 +19,4 @@ targets = [
 ]
 
 [dependencies]
-libnv-sys = "0.2.1"
+libnv-sys = "0.3.0"


### PR DESCRIPTION
capsicum-rs can now be built without bindgen, which means that llvm need no longer be installed.